### PR TITLE
Minor: Add instructions for building with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apache DataFusion Blog Content
 
-This repository contains the Apache DataFusion blog content.
+This repository contains the Apache DataFusion blog at https://datafusion.apache.org/blog/
 
 ## Setup for Mac
 
@@ -30,12 +30,27 @@ Should be `ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin23]` or 
 gem install jekyll bundler
 ```
 
-## Preview site locally
+### Preview site locally
 
 ```shell
 cd site
 bundle exec jekyll serve
 ```
+
+## Setup for Docker
+
+If you don't wish to change or install ruby and nodejs locally, you can use docker to build and preview the site with a command like:
+
+```shell
+docker run -v `pwd`:/datafusion-site -p 4000:4000 -it ruby bash
+cd datafusion-site
+gem install jekyll bundler
+bundle install
+# Serve using local container address
+bundle exec jekyll serve --host 0.0.0.0
+```
+
+Then open http://localhost:4000/blog/ to see the blog locally
 
 ## Publish site
 


### PR DESCRIPTION
part of https://github.com/apache/datafusion/issues/9602

I am preparing to write a blog post for the imminent release of DataFusion 40 and I need to know how to see such posts locally

You can see the changes rendered here: https://github.com/alamb/datafusion-site/tree/alamb/readme_tweak?tab=readme-ov-file#apache-datafusion-blog-content