### PR TITLE
Minor: Add Link to DataFusion home page

### DIFF
--- a/about.markdown
+++ b/about.markdown
@@ -4,5 +4,7 @@ title: About
 permalink: /about/
 ---
 
-Apache DataFusion is a very fast, extensible query engine for building high-quality
+[Apache DataFusion] is a very fast, extensible query engine for building high-quality
 data-centric systems in Rust, using the Apache Arrow in-memory format.
+
+[Apache DataFusion]: https://datafusion.apache.org/


### PR DESCRIPTION
While working on https://github.com/apache/datafusion-site/pull/25 I noticed a few places on the blog where it would be nice to have backlinks to the DataFusion site

Let's add some more links to make it easier to get back to the main site



