### PR TITLE
Remove apache github link, add link to repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,6 @@ baseurl: "/blog" # the subpath of your site, e.g. /blog
 url: "https://datafusion.apache.org" # the base hostname & protocol for your site, e.g. http://example.com
 logo: img/2x_bgwhite_original.png
 twitter_username: ApacheDataFusio
-github_username:  apache
 markdown: kramdown
 permalink: /:year/:month/:day/:title/
 timezone: UTC

--- a/about.markdown
+++ b/about.markdown
@@ -7,4 +7,7 @@ permalink: /about/
 [Apache DataFusion] is a very fast, extensible query engine for building high-quality
 data-centric systems in Rust, using the Apache Arrow in-memory format.
 
+To update this site, please propose a change to the [source code].
+
 [Apache DataFusion]: https://datafusion.apache.org/
+[source code]: https://github.com/apache/datafusion-site


### PR DESCRIPTION
While working on
- https://github.com/apache/datafusion/issues/13436

I found a few things I would like to propose improving on the blog:

1. Add a link to the about page to find the source code
![Screenshot 2024-11-18 at 9 35 46 AM](https://github.com/user-attachments/assets/0b62a493-90e3-4fd8-bd0f-d98f13a805ba)

2. Remove the link to http://github.com/apache:
![Screenshot 2024-11-18 at 9 36 06 AM](https://github.com/user-attachments/assets/050814ec-0e78-4ae7-b729-1d4f19f27248)
