### PR TITLE
Add information about site-status / publishing to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,5 @@ For example, see https://github.com/apache/datafusion-site/pull/9
 
 #### Check site status
 
-The website is updated from the `asf-site` branch on a schedule, so it may take
-some time for the  changes to be reflected. You can check the status at 
+The website is updated from the `asf-site` branch. You can check the status at 
 [ASF Infra sitesource](https://infra-reports.apache.org/#sitesource)

--- a/README.md
+++ b/README.md
@@ -72,13 +72,18 @@ git checkout asf-site
 git pull
 # create a branch for the publishing
 git checkout -b publish_blog
-# push code upstream
-git push 
 # copy content built from _site directory
 cp -R ../datafusion-site/_site/* .
 git commit -a -m 'Publish blog content'
+# push code upstream
+git push 
 ```
 
 #### Make PR, targeting the `asf-site` branch
 For example, see https://github.com/apache/datafusion-site/pull/9
 
+#### Check site status
+
+The website is updated from the `asf-site` branch on a schedule, so it may take
+some time for the  changes to be reflected. You can check the status at 
+[ASF Infra sitesource](https://infra-reports.apache.org/#sitesource)


### PR DESCRIPTION
I found out about https://infra-reports.apache.org/#sitesource from @timsaucer : https://github.com/apache/datafusion-site/pull/34#issuecomment-2487010402

Let's add that to the readme.