### PR TITLE
Enable CI to publish main

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,8 +1,6 @@
 # This workflow runs the pelican build process after any branch has merged
 # into main and pushes the result to the branch `asf-site`.
-#
-# Publishing is currently disabled until the staging branch process has been validated
-# To enable, remove the publish: false and uncomment the following lines
+
 name: Publish main
 on:
   push:
@@ -16,6 +14,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: apache/infrastructure-actions/pelican@main
         with:
-          publish: 'false'
-          # destination: 'asf-site'
-          # gfm: 'false'
+          destination: 'asf-site'
+          gfm: 'false'

--- a/.github/workflows/stage-site.yml
+++ b/.github/workflows/stage-site.yml
@@ -1,16 +1,9 @@
-# This workflow ensures that any PR targeted at main will build properly.
-# A failure in this workflow should prevent any merging into main. This will
-# build a new branch similar to the PR head branch but with "-staging"
-# appended to the end. If only runs for head branches that match "site/".
-#
-# If you wish to stage your site changes, then you simply need to open
-# a PR with a head branch of `site/` that targets `main`.
-#
-# For example, if you open a PR to merge `site/awesome-update` then this
-# workflow will create a branch `site/awesome-update-staging` that will
-# contain the built contents of the site. A separate ASF process will
-# identify that branch and stage your preview as
-# datafusion-awesome-update.staged.apache.org
+# This workflow will create a staged version of the website. The last branch for which this workflow
+# was run will be published to https://datafusion.staged.apache.org/
+# To enable this work flow, you simply need a PR that has a branch name that begins with `site/`
+# and targets `main`. This workflow will build the site and push the results into the branch
+# `asf-staging`. From there, the ASF infrastructure will identify that a stage site has been
+# built and will publish to the link above.
 
 name: Stage Site
 on:


### PR DESCRIPTION
This PR turns on the workflow that will publish main when merges occur.