### PR TITLE
Adjust site URL to be relative to /blog

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -51,3 +51,4 @@ staging:
   whoami: asf-staging
   profile: ~
   autostage: site/*
+  subdir: blog

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -51,4 +51,3 @@ staging:
   whoami: asf-staging
   profile: ~
   autostage: site/*
-  subdir: blog

--- a/.github/workflows/stage-site.yml
+++ b/.github/workflows/stage-site.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           destination: 'asf-staging'
           gfm: 'false'
+          output: 'blog'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ To use the staging feature of the CI system, push a branch that starts with
 `site/` and create a PR to merge this branch into `main`. When you do so, it
 will trigger a CI process that will build the site and push it to the branch
 `asf-staging`. Once this completes, the ASF infrastructure will auto publish
-this staged branch to https://datafusion.staged.apache.org/
+this staged branch to https://datafusion.staged.apache.org/ It is important
+to note that this staging feature only works for branches on the main repo.
+If you are working on a forked repo, you will need to use the docker approach
+below.
 
 The most recently run staging CI pipeline will be published to this site. If you
 need to republish any branch, simply rerun the `Stage Site` workflow.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 This repository contains the Apache DataFusion blog at https://datafusion.apache.org/blog/
 
+## Testing
+
+There are two ways to preview your blog post before publishing the site. You can
+either locally build and test the site or you can use the auto staging feature
+of the CI system. To locally build the site on your machine, follow the docker
+instructions below.
+
+To use the staging feature of the CI system, push a branch that starts with
+`site/` and create a PR to merge this branch into `main`. When you do so, it
+will trigger a CI process that will build the site and push it to the branch
+`asf-staging`. Once this completes, the ASF infrastructure will auto publish
+this staged branch to https://datafusion.staged.apache.org/
+
+The most recently run staging CI pipeline will be published to this site. If you
+need to republish any branch, simply rerun the `Stage Site` workflow.
+
 ## Setup for Docker
+
+To locally build and preview the site on your computer, you will need to build
+a docker container using these instructions:
 
 ```shell
 git clone https://github.com/apache/infrastructure-actions.git
@@ -28,7 +47,7 @@ See the [ASF-Pelican](https://infra.apache.org/asf-pelican.html) site for most d
 on how this process works.
 
 To preview your site live, create a branch named `site/my-feature-x`. This should
-auto-publish to https://datafusion.staged.apache.org/blog
+auto-publish to https://datafusion.staged.apache.org/
 
 When you are satisfied with the staged branch, merging into `main` should cause
 the site to build via github actions and publish.

--- a/content/theme/templates/menu.html
+++ b/content/theme/templates/menu.html
@@ -9,7 +9,7 @@
         <div class="collapse navbar-collapse" id="navbarADP">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item">
-                    <a class="nav-link" href="/about.html">About</a>
+                    <a class="nav-link" href="/blog/about.html">About</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="/blog/feed.xml">RSS</a>

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,7 +3,7 @@ import datetime
 SITENAME = 'Apache DataFusion Blog'
 SITEDESC = 'The official new and blog for the Apache DataFusion project'
 SITEDOMAIN = 'datafusion.apache.org'
-SITEURL = 'https://datafusion.apache.org'
+SITEURL = 'https://datafusion.apache.org/blog'
 SITELOGO = 'https://datafusion.apache.org/favicon.ico'
 SITEREPOSITORY = 'https://github.com/apache/datafusion-site/blob/main/content/'
 CURRENTYEAR = datetime.date.today().year
@@ -63,7 +63,7 @@ ASF_GENID = {
 # blogs/README.md is not intended for publication
 IGNORE_FILES = [ 'theme', 'README.md' ]
 
-FEED_RSS = "feed.xml"
+FEED_RSS = "blog/feed.xml"
 
 MARKDOWN = {
     'extension_configs': {

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,8 +3,8 @@ import datetime
 SITENAME = 'Apache DataFusion Blog'
 SITEDESC = 'The official new and blog for the Apache DataFusion project'
 SITEDOMAIN = 'datafusion.apache.org'
-SITEURL = 'https://datafusion.apache.org/blog'
-SITELOGO = 'https://datafusion.apache.org/favicon.ico'
+SITEURL = 'https://datafusion.staged.apache.org'
+SITELOGO = 'https://datafusion.staged.apache.org/favicon.ico'
 SITEREPOSITORY = 'https://github.com/apache/datafusion-site/blob/main/content/'
 CURRENTYEAR = datetime.date.today().year
 TRADEMARKS = 'Apache HTTP Server, Apache, and the Apache feather logo are trademarks of The Apache Software Foundation.'
@@ -37,9 +37,10 @@ AUTHORS_SAVE_AS = ''
 ARCHIVES_SAVE_AS = ''
 # Disable articles by pointing to a (should-be-absent) subdir
 ARTICLE_PATHS = [ 'blog' ]
-# needed to create blogs page
-ARTICLE_URL = 'blog/{date:%Y}/{date:%m}/{date:%d}/{filename}'
-ARTICLE_SAVE_AS = 'blog/{date:%Y}/{date:%m}/{date:%d}/{filename}/index.html'
+# needed to create blogs page. Do not put the preceeding /blog here because
+# that will be added by asf infra when it posts the site
+ARTICLE_URL = '{date:%Y}/{date:%m}/{date:%d}/{filename}'
+ARTICLE_SAVE_AS = '{date:%Y}/{date:%m}/{date:%d}/{filename}/index.html'
 # Disable all processing of .html files
 READERS = { 'html': None, }
 
@@ -62,7 +63,7 @@ ASF_GENID = {
 # blogs/README.md is not intended for publication
 IGNORE_FILES = [ 'theme', 'README.md' ]
 
-FEED_RSS = "blog/feed.xml"
+FEED_RSS = "feed.xml"
 
 MARKDOWN = {
     'extension_configs': {

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -3,8 +3,8 @@ import datetime
 SITENAME = 'Apache DataFusion Blog'
 SITEDESC = 'The official new and blog for the Apache DataFusion project'
 SITEDOMAIN = 'datafusion.apache.org'
-SITEURL = 'https://datafusion.staged.apache.org'
-SITELOGO = 'https://datafusion.staged.apache.org/favicon.ico'
+SITEURL = 'https://datafusion.apache.org'
+SITELOGO = 'https://datafusion.apache.org/favicon.ico'
 SITEREPOSITORY = 'https://github.com/apache/datafusion-site/blob/main/content/'
 CURRENTYEAR = datetime.date.today().year
 TRADEMARKS = 'Apache HTTP Server, Apache, and the Apache feather logo are trademarks of The Apache Software Foundation.'


### PR DESCRIPTION
This PR is designed to set the built site to be relative to the /blog directory since ASF infra puts it there for the urls. I also updated the README to show how to use the staged blog to preview.

After merging I'll do the final step, which is to remove the old site content from the `asf-site` branch and test it. If that breaks for any reason, I'll revert the commit on that branch.

Closes #13 