### PR TITLE
Fix local preview link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pelicanasf content -o blog
 python3 -m http.server 8000
 ```
 
-Navigate in your web browser to [http://localhost:8000/blog] to view the live
+Navigate in your web browser to [http://localhost:8000/blog](http://localhost:8000/blog) to view the live
 website. In your terminal you can press Ctrl+C and rerun the last two commands
 to rebuild and publish the site.
 


### PR DESCRIPTION
A link on the main web page doesn't render correctly:

 https://github.com/apache/datafusion-site?tab=readme-ov-file#setup-for-docker

![Screenshot 2025-04-15 at 8 40 44 AM](https://github.com/user-attachments/assets/c8ce9b7e-662a-43b2-8f66-b2f05ae0be0b)
