### PR TITLE
add infrastructure-actions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ vendor
 output
 /blog/
 !*/blog/
+infrastructure-actions/
 


### PR DESCRIPTION
Local setup clones the `apache/infrastructure-actions` repo into the `infrastructure-actions` local directory. 
See https://github.com/apache/datafusion-site?tab=readme-ov-file#setup-for-docker

Lets add this folder to gitignore so it wont be accidentally checked in 