### PR TITLE
github: turn on discussion

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,6 +24,7 @@ notifications:
   commits: commits@datafusion.apache.org
   issues: github@datafusion.apache.org
   pullrequests: github@datafusion.apache.org
+  discussions: github@datafusion.apache.org
   jira_options: link label worklog
 github:
   description: "Apache DataFusion Web Site"


### PR DESCRIPTION
Related to #80
Turn on discussion feature on github for giscus 