### PR TITLE
Blog: Fix page overflow

### DIFF
--- a/content/theme/templates/footer.html
+++ b/content/theme/templates/footer.html
@@ -1,6 +1,6 @@
     <!-- footer -->
-    <div class="row">
-      <div class="large-12 medium-12 columns">
+    <div class="row g-0">
+      <div class="col-12">
         <p style="font-style: italic; font-size: 0.8rem; text-align: center;">
           Copyright {{ CURRENTYEAR }}, <a href="https://www.apache.org/">The Apache Software Foundation</a>, Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.<br/>
           Apache&reg; and the Apache feather logo are trademarks of The Apache Software Foundation.


### PR DESCRIPTION
Small fix for a problem that was causing a page y-overflow on the blog, making it awkward to scroll especially on mobile.