### PR TITLE
Blog: Limit max width

### DIFF
--- a/content/css/app.css
+++ b/content/css/app.css
@@ -1,0 +1,3 @@
+.main-content {
+    max-width: 900px;
+}

--- a/content/theme/templates/blogindex.html
+++ b/content/theme/templates/blogindex.html
@@ -1,6 +1,6 @@
 <div id="contents">
     <div class="bg-white p-5 rounded">
-        <div class="col-sm-8 mx-auto">
+        <div class="col-md-10 col-lg-8 mx-auto main-content">
 
             <h3>Welcome to the Apache DataFusion Blog!</h3>
             <p><i>Here you can find the latest updates from DataFusion and related projects.</i></p>

--- a/content/theme/templates/generic.html
+++ b/content/theme/templates/generic.html
@@ -3,7 +3,7 @@
 <!-- article contents -->
 <div id="contents">
     <div class="bg-white p-5 rounded">
-        <div class="col-sm-8 mx-auto">
+        <div class="col-md-10 col-lg-8 mx-auto main-content">
           <h1>
             {{ article.title }}
           </h1>

--- a/content/theme/templates/styles.html
+++ b/content/theme/templates/styles.html
@@ -2,5 +2,6 @@
 <link href="/blog/css/fontawesome.all.min.css" rel="stylesheet">
 <link href="/blog/css/headerlink.css" rel="stylesheet">
 <link href="/blog/highlight/default.min.css" rel="stylesheet">
+<link href="/blog/css/app.css" rel="stylesheet">
 <script src="/blog/highlight/highlight.js"></script>
 <script>hljs.highlightAll();</script>


### PR DESCRIPTION
Closes #100.

The `max-width` was set to 900px. I believe we could make it even smaller, but 900px looks good. I also changed some `col-` to give it more space in smaller devices.

Before:
<img width="2559" height="1026" alt="image" src="https://github.com/user-attachments/assets/276672d1-dcee-44a1-8034-f6e566e6d76f" />
After:
<img width="2559" height="1166" alt="image" src="https://github.com/user-attachments/assets/912915b3-accc-44c0-88f8-09dac23b1c24" />

Before:
<img width="2559" height="989" alt="image" src="https://github.com/user-attachments/assets/fcb388c4-5f98-480a-b5bf-869b71d8fbd2" />

After:
<img width="2559" height="1127" alt="image" src="https://github.com/user-attachments/assets/f76c48af-f94c-4344-b411-d97b0f039932" />
