### PR TITLE
Blog: Center article content

### DIFF
--- a/content/css/app.css
+++ b/content/css/app.css
@@ -2,6 +2,10 @@
     max-width: 900px;
 }
 
+.toc-container {
+    max-width: 400px;
+}
+
 .toc {
     position: sticky;
     top: 20px;
@@ -12,7 +16,6 @@
     border-radius: 10px;
     border-width: 1px;
     border-style: solid;
-    max-width: 400px;
 }
 
 .toctitle {

--- a/content/theme/templates/generic.html
+++ b/content/theme/templates/generic.html
@@ -9,7 +9,7 @@
         <p>Posted on: {{ article.locale_date }} by {{ article.author }}</p>
 
         {% if article.toc %}
-        <aside class="d-md-none mb-2">
+        <aside class="toc-container d-md-none mb-2">
           {{ article.toc }}
         </aside>
         {% endif %}
@@ -19,7 +19,7 @@
         {% include "comments.html" %}
       </div>
       {% if article.toc %}
-      <aside class="d-none d-md-block col-md-4 col-xl-3 ms-xl-2">
+      <aside class="toc-container d-none d-md-block col-md-4 col-xl-3 ms-xl-2">
         {{ article.toc }}
       </aside>
       {% endif %}


### PR DESCRIPTION
The blog articles are not quite as centered, since the max width of the table of contents is not applied to the `aside` container.

Before:
<img width="2558" height="1104" alt="image" src="https://github.com/user-attachments/assets/5b06f974-41d9-40c5-a5b7-2b03c0e4c666" />

After:
<img width="2559" height="916" alt="image" src="https://github.com/user-attachments/assets/e6773623-3167-445d-8159-bedb4f36f0d1" />
