### PR TITLE
Add blog post for DataFusion 51.0.0

### DIFF
--- a/content/blog/2025-11-25-datafusion-51.0.0.md
+++ b/content/blog/2025-11-25-datafusion-51.0.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Apache DataFusion 50.0.0 Released
-date: 2025-09-29
+title: Apache DataFusion 51.0.0 Released
+date: 2025-11-25
 author: pmc
 categories: [release]
 ---
@@ -27,401 +27,92 @@ limitations under the License.
 
 [TOC]
 
-<!-- see https://github.com/apache/datafusion/issues/16347 for details -->
-
 ## Introduction
 
-We are proud to announce the release of [DataFusion 50.0.0]. This blog post
-highlights some of the major improvements since the release of [DataFusion
-49.0.0]. The complete list of changes is available in the [changelog].
-Thanks to [numerous contributors] for making this release possible!
+We are proud to announce the release of [DataFusion 51.0.0]. This post highlights
+some of the major improvements since [DataFusion 50.0.0]. The complete list of
+changes is available in the [changelog]. Thanks to [numerous contributors] for
+making this release possible!
 
-[DataFusion 50.0.0]: https://crates.io/crates/datafusion/50.0.0
-[DataFusion 49.0.0]: https://datafusion.apache.org/blog/2025/07/28/datafusion-49.0.0/
-[changelog]: https://github.com/apache/datafusion/blob/branch-50/dev/changelog/50.0.0.md
-[numerous contributors]: https://github.com/apache/datafusion/blob/branch-50/dev/changelog/50.0.0.md#credits
-
+[DataFusion 51.0.0]: https://crates.io/crates/datafusion/51.0.0
+[DataFusion 50.0.0]: https://datafusion.apache.org/blog/2025/09/29/datafusion-50.0.0/
+[changelog]: https://github.com/apache/datafusion/blob/branch-51/dev/changelog/51.0.0.md
+[numerous contributors]: https://github.com/apache/datafusion/blob/branch-51/dev/changelog/51.0.0.md#credits
 
 ## Performance Improvements 🚀
 
-DataFusion continues to focus on enhancing performance, as shown in ClickBench
-and other benchmark results.
+**Faster `CASE` expressions**
 
-<img src="/blog/images/datafusion-50.0.0/performance_over_time_clickbench.png"
-  width="100%" class="img-responsive" alt="ClickBench performance results over time for DataFusion" />
+A series of optimizer and execution changes (see the
+[CASE performance epic](https://github.com/apache/datafusion/issues/18075))
+significantly reduces work when evaluating complex `CASE` branches. Expressions
+short‑circuit earlier, reuse partial results, and avoid unnecessary scattering,
+speeding up common ETL patterns.
 
-**Figure 1**: Average and median normalized query execution times for ClickBench queries for each git revision.
-Query times are normalized using the ClickBench definition. See the 
-[DataFusion Benchmarking Page](https://alamb.github.io/datafusion-benchmarking/) 
-for more details.
+**Fewer object store round-trips for Parquet**
 
-Here are some noteworthy optimizations added since DataFusion 49:
-
-**Dynamic Filter Pushdown Improvements**
-
-The dynamic filter pushdown optimization, which allows runtime filters to cut
-down on the amount of data read, has been extended to support **inner hash
-joins**, dramatically improving performance when one relation is relatively
-small or filtered by a highly selective predicate. More details can be found in
-the [Dynamic Filter Pushdown for Hash Joins](#dynamic-filter-pushdown-for-hash-joins) section below.
-The dynamic filters in the TopK operator have also been improved in DataFusion
-50.0.0, further increasing the effectiveness and efficiency of the optimization.
-More details can be found in this
-[ticket](https://github.com/apache/datafusion/pull/16433).
-
-**Nested Loop Join Optimization**
-
-The nested loop join operator has been rewritten to reduce execution time and memory
-usage by adopting a finer-grained approach. Specifically, we now limit the 
-intermediate data size to around a single `RecordBatch` for better memory
-efficiency, and we have eliminated redundant conversions from the old 
-implementation to further improve execution speed.
-When evaluating this new approach in a microbenchmark, we measured up to a 5x
-improvement in execution time and a 99% reduction in memory usage. More details and
-results can be found in this
-[ticket](https://github.com/apache/datafusion/pull/16996).
-
-**Parquet Metadata Caching**
-
-DataFusion now automatically caches the metadata of Parquet files (statistics,
-page indexes, etc.), to avoid unnecessary disk/network round-trips. This is
-especially useful when querying the same table multiple times over relatively
-slow networks, allowing us to achieve an order of magnitude faster execution
-time when running many small reads over large files. More information can be
-found in the [Parquet Metadata Cache](#parquet-metadata-cache) section.
-
-## Community Growth 📈
-
-Between `49.0.0` and `50.0.0`, we continue to see our community grow:
-
-1. Qi Zhu ([zhuqi-lucas](https://github.com/zhuqi-lucas)) and Yoav Cohen
-   ([yoavcloud](https://github.com/yoavcloud)) became committers. See the
-   [mailing list] for more details.
-2. In the [core DataFusion repo] alone, we reviewed and accepted 318 PRs
-   from 79 different committers, created over 235 issues, and closed 197 of them
-   🚀. All changes are listed in the detailed [changelogs].
-3. DataFusion published several blogs, including *[Using External Indexes, Metadata Stores, Catalogs and
-   Caches to Accelerate Queries on Apache Parquet]*, *[Dynamic Filters:
-   Passing Information Between Operators During Execution for 25x Faster
-   Queries]*, and *[Implementing User Defined Types and Custom Metadata 
-   in DataFusion]*.
-
-<!--
-# Unique committers
-$ git shortlog -sn 49.0.0..50.0.0  . | wc -l
-    79
-# commits
-$ git log --pretty=oneline 49.0.0..50.0.0  . | wc -l
-    318
-
-https://crates.io/crates/datafusion/49.0.0
-DataFusion 49 released July 25, 2025
-
-https://crates.io/crates/datafusion/50.0.0
-DataFusion 50 released September 16, 2025
-
-Issues created in this time: 117 open, 118 closed = 235 total
-https://github.com/apache/datafusion/issues?q=is%3Aissue+created%3A2025-07-25..2025-09-16
-
-Issues closed: 197
-https://github.com/apache/arrow-datafusion/issues?q=is%3Aissue+closed%3A2025-07-25..2025-09-16
-
-PRs merged in this time 371
-https://github.com/apache/arrow-datafusion/pulls?q=is%3Apr+merged%3A2025-07-25..2025-09-16
--->
-
-
-[core DataFusion repo]: https://github.com/apache/arrow-datafusion
-[changelogs]: https://github.com/apache/datafusion/tree/main/dev/changelog
-[mailing list]: https://lists.apache.org/list.html?dev@datafusion.apache.org
-[Using External Indexes, Metadata Stores, Catalogs and Caches to Accelerate Queries on Apache Parquet]: https://datafusion.apache.org/blog/2025/08/15/external-parquet-indexes/
-[Dynamic Filters: Passing Information Between Operators During Execution for 25x Faster Queries]: https://datafusion.apache.org/blog/2025/09/10/dynamic-filters/
-[Implementing User Defined Types and Custom Metadata in DataFusion]: https://datafusion.apache.org/blog/2025/09/21/custom-types-using-metadata/
+DataFusion now sets a default `metadata_size_hint` for Parquet scans
+([#18118](https://github.com/apache/datafusion/issues/18118)), avoiding the extra
+“last 8‑byte” request many clouds require to read file footers. Remote scans
+typically drop from five requests to four per file, cutting latency and transfer
+costs without any application changes.
 
 ## New Features ✨
 
-### Improved Spilling Sorts for Larger-than-Memory Datasets
+### Decimal32/Decimal64 Everywhere
 
-DataFusion has long been able to sort datasets that do not fit entirely in memory,
-but still struggled with particularly large inputs or highly memory-constrained 
-setups. Larger-than-memory sorts in DataFusion 50.0.0 have been improved with the recent introduction
-of multi-level merge sorts (more details in the respective
-[ticket](https://github.com/apache/datafusion/pull/15700)). It is now
-possible to execute almost any sorting query that would have previously triggered *out-of-memory*
-errors, by relying on disk spilling. Thanks to [Raz Luvaton], [Yongting You], and
-[ding-young] for delivering this feature.
+DataFusion now treats the smaller decimal types as first-class citizens
+([#17501](https://github.com/apache/datafusion/pull/17501)). Aggregations like
+`SUM`, `AVG`, `MIN/MAX`, and window functions work seamlessly with `Decimal32`
+and `Decimal64`, removing a common source of “type not supported” errors for
+financial and sensor workloads.
 
-[Raz Luvaton]: https://github.com/rluvaton
-[Yongting You]: https://github.com/2010YOUY01
-[ding-young]: https://github.com/ding-young
+### SQL Pipe Operators
 
-### Dynamic Filter Pushdown for Hash Joins
-
-The [dynamic filter pushdown
-optimization](https://datafusion.apache.org/blog/2025/09/10/dynamic-filters/)
-has been extended to inner hash joins, dramatically reducing the amount of
-scanned data in some workloads—a technique sometimes referred to as
-[*Sideways Information Passing*](https://www.cs.cmu.edu/~15721-f24/papers/Sideways_Information_Passing.pdf).
-
-These filters are automatically applied to inner hash joins, while future work
-will introduce them to other join types. 
-
-For example, given a query that looks for a specific customer and
-their orders, DataFusion can now filter the `orders` relation based on the
-`c_custkey` of the target customer, reducing the amount of data
-read from disk by orders of magnitude.
+Pipe operators from sqlparser are now executable in DataFusion
+([#17278](https://github.com/apache/datafusion/pull/17278)), enabling inline
+transforms such as:
 
 ```sql
--- retrieve the orders of the customer with c_phone = '25-989-741-2988'
-SELECT *
-FROM customer
-JOIN orders ON c_custkey = o_custkey
-WHERE c_phone = '25-989-741-2988';
+SELECT * FROM t
+|> WHERE a > 10
+|> ORDER BY b
+|> LIMIT 5;
 ```
 
-The following shows an execution plan in DataFusion 50.0.0 with this optimization:
+This syntax keeps multi-step transformations concise while preserving regular
+SQL semantics.
+
+### Object Store Profiling in `datafusion-cli`
+
+The CLI gained built-in instrumentation to trace object store calls
+([#17207](https://github.com/apache/datafusion/issues/17207)). Toggle profiling
+with a single command and inspect the exact `GET`/`LIST` requests issued during
+query execution:
 
 ```sql
-HashJoinExec
-    DataSourceExec: <-- read customer
-      predicate=c_phone@4 = 25-989-741-2988
-      metrics=[output_rows=1, ...]
-    DataSourceExec: <-- read orders
-      -- dynamic filter is added here, filtering directly at scan time
-      predicate=DynamicFilterPhysicalExpr [ o_custkey@1 >= 1 AND o_custkey@1 <= 1 ]
-      -- the number of output rows is kept to a minimum
-      metrics=[output_rows=11, ...]
+> \\object_store_profiling trace
+> SELECT COUNT(*) FROM 'https://datasets.clickhouse.com/.../hits_1.parquet';
+-- trace output includes operation, range, size, path, and duration
 ```
 
-Because there is a single customer in this query,
-almost all rows from `orders` are filtered out by the join. 
-In previous versions of DataFusion, the entire `orders` relation would be
-scanned to join with the target customer, but now the dynamic filter pushdown can
-filter it right at the source, minimizing the amount of data decoded.
+This makes it far easier to diagnose slow remote scans and validate caching
+strategies.
 
-More information can be found in the respective
-[ticket](https://github.com/apache/datafusion/pull/16445) and the next step will be to
-[extend the dynamic filters to other types of joins](https://github.com/apache/datafusion/issues/16973), such as `LEFT` and
-`RIGHT` outer joins. Thanks to [Adrian Garcia Badaracco], [Qi Zhu], [xudong963], [Daniël Heres], and [Lía Adriana]
-for delivering this feature.
+### Better Defaults for Remote Parquet Reads
 
-[Adrian Garcia Badaracco]: https://github.com/adriangb
-[Qi Zhu]: https://github.com/zhuqi-lucas
-[xudong963]: https://github.com/xudong963
-[Daniël Heres]: https://github.com/Dandandan
-[Lía Adriana]: https://github.com/LiaCastaneda
-
-### Parquet Metadata Cache
-
-The metadata of Parquet files (statistics, page indexes, etc.) is now
-automatically cached when using the built-in [ListingTable], which reduces disk/network round-trips and repeated decoding
-of the same information. With a simple microbenchmark that executes point reads
-(e.g., `SELECT v FROM t WHERE k = x`) over large files, we measured a 12x
-improvement in execution time (more details can be found in the respective
-[ticket](https://github.com/apache/datafusion/pull/16971)). This optimization
-is production ready and enabled by default (more details in the
-[Epic](https://github.com/apache/datafusion/issues/17000)).
-Thanks to [Nuno Faria], [Jonathan Chen], [Shehab Amin], [Oleks V], [Tim Saucer], and [Blake Orth] for delivering this feature.
-
-[ListingTable]: https://docs.rs/datafusion/latest/datafusion/datasource/listing/struct.ListingTable.html
-[Nuno Faria]: https://github.com/nuno-faria
-[Jonathan Chen]: https://github.com/jonathanc-n
-[Shehab Amin]: https://github.com/shehabgamin
-[Oleks V]: https://github.com/comphead
-[Tim Saucer]: https://github.com/timsaucer
-[Blake Orth]: https://github.com/BlakeOrth
-
-Here is an example of the metadata cache in action:
-
-```sql
--- disabling the metadata cache
-> SET datafusion.runtime.metadata_cache_limit = '0M';
-
--- simple query (t.parquet: 100M rows, 3 cols)
-> EXPLAIN ANALYZE SELECT * FROM 't.parquet' LIMIT 1;
-DataSourceExec: ... metrics=[..., metadata_load_time=229.196422ms, ...]
-Elapsed 0.246 seconds.
-
--- enabling the metadata cache
-> SET datafusion.runtime.metadata_cache_limit = '50M';
-
-> EXPLAIN ANALYZE SELECT * FROM 't.parquet' LIMIT 1;
-DataSourceExec: ... metrics=[..., metadata_load_time=228.612µs, ...]
-Elapsed 0.003 seconds. -- 82x improvement in this specific query
-```
-
-
-The cache can be configured with the following runtime parameter:
-
-```sql
-datafusion.runtime.metadata_cache_limit
-```
-
-The default [`FileMetadataCache`](https://docs.rs/datafusion/latest/datafusion/execution/cache/cache_manager/trait.FileMetadataCache.html) uses a
-least-recently-used eviction algorithm and up to 50MB of memory.
-If the underlying file changes, the cache is automatically invalidated.
-Setting the limit to 0 will disable any metadata caching. As with most APIs in
-DataFusion, users can provide their own behavior using a custom
-[`FileMetadataCache`](https://docs.rs/datafusion/50.0.0/datafusion/execution/cache/cache_manager/trait.FileMetadataCache.html)
-implementation when setting up the [`RuntimeEnv`](https://docs.rs/datafusion/latest/datafusion/execution/runtime_env/struct.RuntimeEnv.html).
-
-
-For users with custom [`TableProvider`](https://docs.rs/datafusion/latest/datafusion/catalog/trait.TableProvider.html):
-
-* If the custom provider uses the
-[`ParquetFormat`](https://docs.rs/datafusion/latest/datafusion/datasource/file_format/parquet/struct.ParquetFormat.html), caching will work
-without any changes.
-
-* Otherwise the
-[`CachedParquetFileReaderFactory`](https://docs.rs/datafusion/latest/datafusion/datasource/physical_plan/parquet/struct.CachedParquetFileReaderFactory.html)
-can be provided when creating a
-[`ParquetSource`](https://docs.rs/datafusion/latest/datafusion/datasource/physical_plan/struct.ParquetSource.html).
-
-Users can inspect the cache contents through the
-[`FileMetadataCache::list_entries`](https://docs.rs/datafusion/latest/datafusion/execution/cache/cache_manager/trait.FileMetadataCache.html#tymethod.list_entries)
-method, or with the
-[`metadata_cache()`](https://datafusion.apache.org/user-guide/cli/functions.html#metadata-cache)
-function in `datafusion-cli`:
-
-
-```sql
-> SELECT * FROM metadata_cache();
-+---------------+-------------------------+-----------------+--------------------------+---------+---------------------+------+-----------------+
-| path          | file_modified           | file_size_bytes | e_tag                    | version | metadata_size_bytes | hits | extra           |
-+---------------+-------------------------+-----------------+--------------------------+---------+---------------------+------+-----------------+
-| .../t.parquet | 2025-09-21T17:40:13.650 | 420827020       | 0-63f5331fb4458-19154f8c | NULL    | 44480534            | 27   | page_index=true |
-+---------------+-------------------------+-----------------+--------------------------+---------+---------------------+------+-----------------+
-1 row(s) fetched.
-Elapsed 0.003 seconds.
-```
-
-
-### `QUALIFY` Clause
-
-DataFusion now supports the `QUALIFY` SQL clause
-([#16933](https://github.com/apache/datafusion/pull/16933)), which simplifies
-filtering window function output (similar to how `HAVING` filters
-aggregation output).
-
-For example, filtering the output of the `rank()` function previously
-required a query like this:
-
-```sql
-SELECT a, b, c
-FROM (
-   SELECT a, b, c, rank() OVER(PARTITION BY a ORDER BY b) as rk
-   FROM t
-)
-WHERE rk = 1
-```
-
-The same query can now be written like this:
-```sql
-SELECT a, b, c, rank() OVER(PARTITION BY a ORDER BY b) as rk
-FROM t
-QUALIFY rk = 1
-```
-
-Although it is not part of the SQL standard (yet), it has been gaining
-adoption in several SQL analytical systems such as DuckDB, Snowflake, and
-BigQuery. Thanks to [Huaijin] and [Jonah Gao] for delivering this feature.
-
-[Huaijin]: https://github.com/haohuaijin
-[Jonah Gao]: https://github.com/jonahgao
-
-### `FILTER` Support for Window Functions
-
-Continuing the theme, the `FILTER` clause has been extended to support
-[aggregate window functions](https://github.com/apache/datafusion/pull/17378).
-It allows these functions to apply to specific rows without having to
-rely on `CASE` expressions, similar to what was already possible with regular
-aggregate functions.
-
-For example, we can gather multiple distinct sets of values matching different
-criteria with a single pass over the input:
-
-```sql
-SELECT 
-  ARRAY_AGG(c2) FILTER (WHERE c2 >= 2) OVER (...)     -- e.g. [2, 3, 4]
-  ARRAY_AGG(CASE WHEN c2 >= 2 THEN c2 END) OVER (...) -- e.g. [NULL, NULL, 2, 3, 4]
-...
-FROM table
-```
-
-Thanks to [Geoffrey Claude] and [Jeffrey Vo] for delivering this feature.
-
-
-[Geoffrey Claude]: https://github.com/geoffreyclaude
-[Jeffrey Vo]: https://github.com/Jefffrey
-
-### `ConfigOptions` Now Available to Functions
-
-DataFusion 50.0.0 now passes session configuration parameters to User-Defined
-Functions (UDFs) via
-[ScalarFunctionArgs](https://docs.rs/datafusion/latest/datafusion/logical_expr/struct.ScalarFunctionArgs.html)
-([#16970](https://github.com/apache/datafusion/pull/16970)). This allows
-behavior that varies based on runtime state; for example, time UDFs can use the
-session-specified time zone instead of just UTC.
-
-Thanks to [Bruce Ritchie], [Piotr Findeisen], [Oleks V], and [Andrew Lamb] for delivering this feature.
-
-[Bruce Ritchie]: https://github.com/Omega359
-[Piotr Findeisen]: https://github.com/findepi
-[Oleks V]: https://github.com/comphead
-[Andrew Lamb]: https://github.com/alamb
-
-### Additional Apache Spark Compatible Functions
-
-Finally, due to Apache Spark's impact on analytical processing, many DataFusion
-users desire Spark compatibility in their workloads, so DataFusion provides a
-set of Spark-compatible functions in the [datafusion-spark](https://crates.io/crates/datafusion-spark) crate.
-You can read more about this project in the [announcement] and [epic].
-DataFusion 50.0.0 adds several new such functions:
-
-- [`array`](https://github.com/apache/datafusion/pull/16936)
-- [`bit_get/bit_count`](https://github.com/apache/datafusion/pull/16942)
-- [`bitmap_count`](https://github.com/apache/datafusion/pull/17179)
-- [`crc32/sha1`](https://github.com/apache/datafusion/pull/17032)
-- [`date_add/date_sub`](https://github.com/apache/datafusion/pull/17024)
-- [`if`](https://github.com/apache/datafusion/pull/16946)
-- [`last_day`](https://github.com/apache/datafusion/pull/16828)
-- [`like/ilike`](https://github.com/apache/datafusion/pull/16962)
-- [`luhn_check`](https://github.com/apache/datafusion/pull/16848)
-- [`mod/pmod`](https://github.com/apache/datafusion/pull/16829)
-- [`next_day`](https://github.com/apache/datafusion/pull/16780)
-- [`parse_url`](https://github.com/apache/datafusion/pull/16937)
-- [`rint`](https://github.com/apache/datafusion/pull/16924)
-- [`width_bucket`](https://github.com/apache/datafusion/pull/17331)
-
-Thanks to [David López], [Chen Chongchen], [Alan Tang], [Peter Nguyen], and [Evgenii Glotov] for delivering these functions. We are looking for additional help
-reviewing and implementing more functions; please reach out on the [epic] if you are interested.
-
-
-[David López]: https://github.com/davidlghellin
-[Chen Chongchen]: https://github.com/chenkovsky
-[Alan Tang]: https://github.com/Standing-Man
-[Peter Nguyen]: https://github.com/petern48
-[Evgenii Glotov]: https://github.com/SparkApplicationMaster
-[announcement]: https://datafusion.apache.org/blog/2025/07/16/datafusion-48.0.0/#new-datafusion-spark-crate
-[epic]: https://github.com/apache/datafusion/issues/15914
-
-
-## Known Issues / Patchset
-
-As DataFusion continues to mature, we regularly release patch versions to fix issues 
-in major releases. Since the release of `50.0.0`, we have identified a few
-issues, and expect to release `50.1.0` to address them. You can track progress
-in this [ticket](https://github.com/apache/datafusion/issues/17594). 
-
+Alongside the new profiling tools, DataFusion now uses a larger default Parquet
+footer prefetch hint so the first request usually includes the full footer
+([#18118](https://github.com/apache/datafusion/issues/18118)). Users can tune it
+via `datafusion.execution.parquet.metadata_size_hint`, and disable prefetching
+by setting it to `0`.
 
 ## Upgrade Guide and Changelog
 
-Upgrading to 50.0.0 should be straightforward for most users. Please review the
+Upgrading to 51.0.0 should be straightforward for most users. Please review the
 [Upgrade Guide](https://datafusion.apache.org/library-user-guide/upgrading.html)
 for details on breaking changes and code snippets to help with the transition.
-Recently, some users have reported success automatically upgrading DataFusion by
-pairing AI tools with the upgrade guide. For a comprehensive list of all
-changes, please refer to the [changelog].
+For a comprehensive list of all changes, please refer to the [changelog].
 
 ## About DataFusion
 


### PR DESCRIPTION
- Closes https://github.com/apache/datafusion/issues/18548

For anyone curious, I asked `codex` to draft this PR with the following prompt. It did a pretty good job for the rough draft

<details><summary>Details</summary>
<p>

We are going to write a blog post for the DataFusion 51.0.0 release

We need to cover the major features in this release. If you are unsure of any content, please leave a "TODO" note in the text and we can fill it in later.

I have copied the old release post here as a starting point: `content/blog/2025-11-25-datafusion-51.0.0.md`

Here are the PRs  this release (approx based on dates) - https://github.com/apache/datafusion/pulls?q=is%3Apr+merged%3A2025-09-16..2025-11-08
The changelog is here: https://github.com/apache/datafusion/blob/branch-51/dev/changelog/51.0.0.md

The list of major features can be found here https://github.com/apache/datafusion/issues/17558 under the section "Features to mention in the blog (if they make it)"
(please only include the ones that made it into the release, with a checkmark)


</p>
</details> 