### PR TITLE
Update date for the DataFusion 52 release blog

### DIFF
--- a/content/blog/2026-01-12-datafusion-52.0.0.md
+++ b/content/blog/2026-01-12-datafusion-52.0.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Apache DataFusion 52.0.0 Released
-date: 2026-01-28
+date: 2026-01-12
 author: pmc
 categories: [release]
 ---


### PR DESCRIPTION
I pushed the wrong date on 
- https://github.com/apache/datafusion-site/pull/135

Let's use the actual date of release, which is 2026-01-12: https://crates.io/crates/datafusion/52.0.0

<img width="1053" height="421" alt="Screenshot 2026-01-28 at 2 41 21 PM" src="https://github.com/user-attachments/assets/c2c5b199-383d-4c2e-8e68-0346e29d445f" />
