### PR TITLE
Minor: add links to CASE blog in 51.0.0 and 52.0.0 release posts

### DIFF
--- a/content/blog/2025-11-25-datafusion-51.0.0.md
+++ b/content/blog/2025-11-25-datafusion-51.0.0.md
@@ -60,12 +60,13 @@ for more details.
 This release builds on the [CASE performance epic] with significant improvements.
 Expressions short‑circuit earlier, reuse partial results, and avoid unnecessary
 scattering, speeding up common ETL patterns. Thanks to [pepijnve], [chenkovsky],
-and [petern48] for leading this effort. We hope to share more details on our
-implementation in a future post.
+and [petern48] for leading this effort. You can find more details in the
+[Optimizing SQL CASE Expression Evaluation] blog post.
 
 [pepijnve]: https://github.com/pepijnve
 [chenkovsky]: https://github.com/chenkovsky
 [petern48]: https://github.com/petern48
+[Optimizing SQL CASE Expression Evaluation]: /blog/2026/02/02/datafusion_case/
 
 ### Better Defaults for Remote Parquet Reads
 

--- a/content/blog/2026-01-12-datafusion-52.0.0.md
+++ b/content/blog/2026-01-12-datafusion-52.0.0.md
@@ -59,7 +59,8 @@ END
 
 This is the final work in our `CASE` performance epic ([#18075]), which has
 improved `CASE` evaluation significantly. Related PRs [#18183]. Thanks to
-[rluvaton] and [pepijnve] for the implementation.
+[rluvaton] and [pepijnve] for the implementation. See the
+[Optimizing SQL CASE Expression Evaluation] blog post for more details.
 
 [rluvaton]: https://github.com/rluvaton
 [pepijnve]: https://github.com/pepijnve
@@ -67,6 +68,7 @@ improved `CASE` evaluation significantly. Related PRs [#18183]. Thanks to
 
 [#18075]: https://github.com/apache/datafusion/issues/18075
 [#18183]: https://github.com/apache/datafusion/pull/18183
+[Optimizing SQL CASE Expression Evaluation]: /blog/2026/02/02/datafusion_case/
 
 ### `MIN`/`MAX` Aggregate Dynamic Filters
 


### PR DESCRIPTION
- Follow on to https://github.com/apache/datafusion-site/pull/122 from @pepijnve 

Let's cross promote/link the new blog about CASE evaluation: https://datafusion.apache.org/blog/2026/02/02/datafusion_case

By adding a link in the release blogs