### PR TITLE
fixed makefile which pinned old issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ sync-repo: clone-repo
 		exit 1; \
 	fi; \
 	echo "Syncing with origin/main..."; \
-	git fetch --depth 1 origin main && \
-	git checkout main && \
-	git reset --hard origin/main
+    git fetch origin main && \
+    git checkout main
+
 
 # builds the Docker image with pelicanasf installed
 build-image:


### PR DESCRIPTION
### **Title**

```
Fix: Track main branch instead of pinned commit in Makefile
```

### **Description**


The infrastructure-actions repository is currently pinned to a specific commit in the Makefile due to a previously reported issue in apache/infrastructure-actions (#218). That issue has since been resolved, but the pinned commit remains outdated.

I attempted to build the local Docker image using the pinned commit hash and encountered URL-related failures, which further suggests that the commit is no longer reliable.

This change updates the Makefile to stop pinning to a fixed commit and instead track the latest `main` branch of the infrastructure-actions repository. This ensures we automatically receive future fixes and reduces the risk of build failures caused by stale dependencies.

**Changes Made :**
- Removed the hardcoded `COMMIT_HASH`
- Updated the `checkout-commit` target to fetch and sync with `origin/main`

fix issue : #144 
