### PR TITLE
Add anchor link to Comments heading

### DIFF
--- a/content/theme/templates/comments.html
+++ b/content/theme/templates/comments.html
@@ -3,9 +3,9 @@
   Loaded only after explicit visitor consent to comply with ASF policy.
 -->
 
-<div id="comments">
+<div>
   <hr>
-  <h3>Comments</h3>
+  <h3 id="comments">Comments<a class="headerlink" href="#comments" title="Permanent link">&para;</a></h3>
 
   <!-- Local loader script -->
   <script src="/content/js/giscus-consent.js" defer></script>


### PR DESCRIPTION
Add a `headerlink` anchor to the Comments `<h3>`, matching the style used by all other blog post headings (hover to reveal ¶ permalink).

- Moved `id="comments"` from the wrapper `<div>` to the `<h3>` to preserve the `#comments` page anchor
- Enables direct linking to the comments section via `#comments`

Tested locally:
http://localhost:8000/blog/2026/03/20/limit-pruning/#comments
<img width="996" height="176" alt="Screenshot 2026-03-28 at 4 25 32 PM" src="https://github.com/user-attachments/assets/c26ff498-ae78-4481-b6a1-565441778c1a" />
