### PR TITLE
Fix giscus-consent.js script path

### DIFF
--- a/content/theme/templates/comments.html
+++ b/content/theme/templates/comments.html
@@ -8,7 +8,7 @@
   <h3>Comments</h3>
 
   <!-- Local loader script -->
-  <script src="/content/js/giscus-consent.js" defer></script>
+  <script src="/blog/js/giscus-consent.js" defer></script>
 
   <!-- Consent UI -->
   <div id="giscus-consent">


### PR DESCRIPTION
I noticed `Failed to load resource: the server responded with a status of 404 ()` on https://datafusion.apache.org/blog/2026/03/20/limit-pruning/
<img width="1392" height="162" alt="Screenshot 2026-03-28 at 4 34 27 PM" src="https://github.com/user-attachments/assets/1f253197-88c7-4844-8960-95eb17c187fa" />

Looks like we're referring to the wrong location for `giscus-consent.js`. 
Its located at https://datafusion.apache.org/blog/js/giscus-consent.js and http://localhost:8000/blog/js/giscus-consent.js (confirmed locally)