### PR TITLE
Add giscus.app to CSP via .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -29,4 +29,6 @@ RewriteRule ^(.*)$ output/$1 [L]
 # CSP permissions for datafusion.apache.org
 # Adding 3rd party service Giscus – Enable Giscus comments for Datafusion blog posts.
 # Approved by VP Data Privacy on 2026-05-09.
+# See https://lists.apache.org/thread/bx9gll7gz0ol74kh7g43tocmnxy16z76
+# (requires login to view)
 SetEnv CSP_PROJECT_DOMAINS "https://giscus.app"

--- a/.htaccess
+++ b/.htaccess
@@ -25,3 +25,8 @@ RewriteRule ^.*$ %1/ [R=301,L]
 RewriteCond %{ENV:REDIRECT_STATUS} ^$
 RewriteCond %{REQUEST_URI} !/output/
 RewriteRule ^(.*)$ output/$1 [L]
+
+# CSP permissions for datafusion.apache.org
+# Adding 3rd party service Giscus – Enable Giscus comments for Datafusion blog posts.
+# Approved by VP Data Privacy on 2026-05-09.
+SetEnv CSP_PROJECT_DOMAINS "https://giscus.app"


### PR DESCRIPTION
This PR adds `https://giscus.app` to the Content Security Policy (CSP) on the `asf-site` branch so the Giscus comments widget can load.
Addition to the CSP has been approved by VP Data Privacy on 2026-05-09.

### Context
The blog templates and `giscus-consent.js` are already deployed but the CSP currently blocks `giscus.app/client.js`:

> Loading the script 'https://giscus.app/client.js' violates the following Content Security Policy directive: "script-src 'self' …"

Per [ASF CSP docs](https://infra.apache.org/tools/csp.html), this adds `SetEnv CSP_PROJECT_DOMAINS` to the root `.htaccess`.

**Why this PR targets `asf-site`:** The Pelican publish workflow only replaces the `output/` directory on `asf-site` — it never touches root-level files like `.htaccess`. The `.htaccess` that the web server reads lives at the root of `asf-site`, so the CSP change must be committed directly to that branch.

Relates to 
- #80 
- #104