### PR TITLE
Fix giscus origin validation in giscus.json

### DIFF
--- a/giscus.json
+++ b/giscus.json
@@ -1,3 +1,3 @@
 {
-  "origins": ["https://datafusion.apache.org/blog"]
+  "origins": ["https://datafusion.apache.org"]
 }


### PR DESCRIPTION
Fixes https://github.com/apache/datafusion-site/pull/173#issuecomment-4415043334
Followup to #172

## What

Change `giscus.json` origins from `https://datafusion.apache.org/blog` to `https://datafusion.apache.org`.

## Why

Giscus checks the embedding page's `window.origin` against the `origins` list using strict equality:

```js
string === window.origin
```

[`window.origin`](https://developer.mozilla.org/en-US/docs/Web/API/Window/origin) is always `protocol + host + port` with **no path**. So `window.origin` on any page under `datafusion.apache.org` is `https://datafusion.apache.org`, which never matched `https://datafusion.apache.org/blog`.

When the origin check fails, giscus redirects its iframe to `https://github.com/orgs/giscus/discussions/1298`, which is then blocked by the site's CSP `frame-src` directive (since `github.com` isn't allowed), producing:

```
Framing 'https://github.com/' violates the following Content Security Policy directive: "frame-src ..."
```

## References

- [Giscus `origins` documentation](https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#origins)
- CSP fix for `giscus.app`: #173
