### PR TITLE
Skip loading giscus on non-production origins

### DIFF
--- a/content/js/giscus-consent.js
+++ b/content/js/giscus-consent.js
@@ -13,8 +13,8 @@
     const notice = document.createElement('p');
     notice.style.color = '#888';
     notice.textContent =
-      'Giscus comments are disabled on localhost. ' +
-      'They will appear on the production site (https://datafusion.apache.org/blog).';
+      'Giscus comments are only available on the production site ' +
+      '(https://datafusion.apache.org/blog).';
     container.appendChild(notice);
     return;
   }

--- a/content/js/giscus-consent.js
+++ b/content/js/giscus-consent.js
@@ -6,6 +6,19 @@
 
   if (!container || !btnLoad || !btnRevoke) return;
 
+  // Giscus only works on the production origin listed in giscus.json.
+  // Show a notice instead of a broken iframe when running elsewhere.
+  if (location.origin !== 'https://datafusion.apache.org') {
+    btnLoad.hidden = true;
+    const notice = document.createElement('p');
+    notice.style.color = '#888';
+    notice.textContent =
+      'Giscus comments are disabled on localhost. ' +
+      'They will appear on the production site (https://datafusion.apache.org/blog).';
+    container.appendChild(notice);
+    return;
+  }
+
   // Giscus configuration 
   // 
   // <script src="https://giscus.app/client.js"


### PR DESCRIPTION
## What

Add an origin guard in `giscus-consent.js` to skip loading giscus when `location.origin` is not `https://datafusion.apache.org`, showing an informational notice instead.

<img width="641" height="191" alt="Screenshot 2026-05-10 at 9 12 24 AM" src="https://github.com/user-attachments/assets/d569bfd5-42ec-41d8-b507-e98aca4bb9dd" />

## Why

Without this guard, running the site locally (e.g. `make serve`) causes giscus to create spurious GitHub Discussions with `http://0.0.0.0:8000/...` backlinks (e.g. https://github.com/apache/datafusion-site/discussions/94).