### PR TITLE
fix: add `output: 'blog'` to publish workflow to fix `/output/` URL leak

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           destination: 'asf-site'
           gfm: 'false'
+          output: 'blog'


### PR DESCRIPTION
## What changes are included in this PR?

Relates to #178

Adds `output: 'blog'` to `publish-site.yml`, matching `stage-site.yml`.

The publish workflow was missing this parameter, so the pelican action defaulted to `output: 'output'`. This caused content to land in `output/` on `asf-site` instead of `blog/`. Since `.asf.yaml` uses `subdir: blog`, an `.htaccess` with rewrite rules was added as a workaround (see INFRA-27512) to internally map requests into `output/`.

Those rewrite rules have a regex bug: the file-extension check (`\.[^./]+$`) matches `.0` at the end of version-number slugs, skipping the trailing-slash redirect. Apache's `mod_dir` then adds the slash but exposes the internal `output/` path:

- `/blog/2026/04/18/datafusion-comet-0.15.0` → 301 → `/blog/output/...` ❌
- `/blog/2026/04/02/datafusion-53.0.0` → 301 → `/blog/output/...` ❌

### What this PR does

With `output: 'blog'`, the pelican action puts built content into `blog/` on `asf-site`, matching what `.asf.yaml` (`subdir: blog`) expects. This is the same configuration `stage-site.yml` already uses for the staging site.

### Deployment safety

This PR is **non-disruptive**. After it deploys:
- `blog/` is created with fresh content on `asf-site`
- `output/` still exists with the old content
- `.htaccess` continues to rewrite requests to `output/` — the site keeps working exactly as before
- No user-visible change until the follow-up PR (#180) is merged

## Follow-up

After this deploys, PR #180 (targeting `asf-site`) should:
1. Remove the rewrite rules from `.htaccess` (keeping only the CSP directive)
2. Remove the stale `output/` directory

At that point, `.asf.yaml`'s `subdir: blog` serves content directly from `blog/` — the same pattern the staging site uses successfully.