### PR TITLE
Revert "fix: add `output: 'blog'` to publish workflow to fix `/output/` URL leak"

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -17,4 +17,3 @@ jobs:
         with:
           destination: 'asf-site'
           gfm: 'false'
-          output: 'blog'


### PR DESCRIPTION
Reverts apache/datafusion-site#179