### PR TITLE
fix: correct changelog link in DataFusion Java 0.1.0 blog post

### DIFF
--- a/content/blog/2026-05-26-datafusion-java-0.1.0.md
+++ b/content/blog/2026-05-26-datafusion-java-0.1.0.md
@@ -40,7 +40,7 @@ as [Apache Arrow] record batches through the [Arrow C Data Interface].
 This post focuses on what the project is and why it exists. The [changelog] has the full list of
 features that landed in 0.1.0.
 
-[changelog]: https://github.com/apache/datafusion-java/blob/0.1.0/CHANGELOG.md
+[changelog]: https://github.com/apache/datafusion-java/blob/0.1.0/dev/changelog/0.1.0.md
 
 ## Why DataFusion Java
 


### PR DESCRIPTION
## Summary
- The changelog link in the DataFusion Java 0.1.0 blog post pointed to a non-existent `CHANGELOG.md` at the repo root (404).
- Updated it to the actual location: `dev/changelog/0.1.0.md`.

## Test plan
- [x] Verified the new URL returns 200