### PR TITLE
fix: Add required ASF policy links to footer

### DIFF
--- a/content/theme/templates/footer.html
+++ b/content/theme/templates/footer.html
@@ -3,7 +3,16 @@
       <div class="col-12">
         <p style="font-style: italic; font-size: 0.8rem; text-align: center;">
           Copyright {{ CURRENTYEAR }}, <a href="https://www.apache.org/">The Apache Software Foundation</a>, Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>.<br/>
-          Apache&reg; and the Apache feather logo are trademarks of The Apache Software Foundation.
+          Apache&reg; and the Apache logo are trademarks of The Apache Software Foundation.
+        </p>
+        <p style="font-size: 0.8rem; text-align: center;">
+          <a href="https://www.apache.org/">Foundation</a> |
+          <a href="https://www.apache.org/events/current-event.html">Events</a> |
+          <a href="https://www.apache.org/licenses/">License</a> |
+          <a href="https://www.apache.org/security/">Security</a> |
+          <a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a> |
+          <a href="https://www.apache.org/foundation/thanks.html">Thanks</a> |
+          <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Adds Foundation, Events, License, Security, Sponsorship, Thanks, and Privacy links per ASF website policy. Updates trademark text where needed.

Checker: https://whimsy.apache.org/site/