### PR TITLE
fix: remove summary frontmatter from Comet EKS blog post

### DIFF
--- a/content/blog/2026-06-03-comet-eks.md
+++ b/content/blog/2026-06-03-comet-eks.md
@@ -4,7 +4,6 @@ title: What two months with the Comet community got our Spark workload on Amazon
 date: 2026-06-03
 author: Manabu McCloskey (AWS), Vara Bonthu (AWS)
 categories: [performance]
-summary: Apache DataFusion Comet now runs a 3TB TPC-DS workload significantly faster than vanilla Spark 3.5.8 on Amazon EKS. This post covers what changed in Comet over the past two releases, and how collaboration between EKS users and maintainers shaped that work. <br></br> <img src="/blog/images/comet-eks/version-arc-slope.png" width="60%" class="img-fluid" alt="TPC-DS performance arc across Comet versions"/>
 ---
 
 <!--


### PR DESCRIPTION
## Rationale

The Comet on Amazon EKS blog post (`content/blog/2026-06-03-comet-eks.md`) was not detected by the external publishing process. On investigation, it is the **only** blog post in the repo that includes a `summary:` frontmatter field. Every other post uses just `layout`, `title`, `date`, `author`, and `categories`.

The `summary` value is a long single line of raw HTML containing embedded double-quotes (`<img src="..." class="...">`), which can trip up a strict frontmatter/YAML parser. Since this is the only structural way the file differs from every post that has published successfully, it is the likely cause.

## Changes

Remove the `summary:` frontmatter field so the post matches the frontmatter format used by all other blog posts.