### PR TITLE
blog: Apache DataFusion Comet 0.17.0 release post

### DIFF
--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -171,9 +171,22 @@ easier to attribute.
 ## Preparing for the 1.0.0 Release
 
 Much of the correctness work in this release is part of a deliberate push toward an eventual **1.0.0 release**.
-Reaching 1.0.0 means being able to state precisely, and stand behind, exactly which Spark expressions Comet
-accelerates and how faithfully it matches Spark on each one. Two efforts in 0.17.0 move directly toward that
-goal.
+Planning for 1.0.0 is being tracked in [issue #4082], where the community is discussing what the milestone
+should mean. The criteria under consideration go well beyond correctness and include:
+
+- Demonstrated cost savings for TPC-H and TPC-DS at SF1000 (1TB) — already met
+- Thorough documentation of compatibility status
+- A review of all configuration options, renaming some for consistency
+- Consistent logging
+- A documented policy for how long each Spark version will be supported
+- A documented process for preventing major performance regressions
+- A documented semantic-versioning policy and what it means for Comet going forward — already agreed
+
+[issue #4082]: https://github.com/apache/datafusion-comet/issues/4082
+
+Correctness sits at the center of that list: reaching 1.0.0 means being able to state precisely, and stand
+behind, exactly which Spark expressions Comet accelerates and how faithfully it matches Spark on each one. Two
+efforts in 0.17.0 move directly toward that goal.
 
 First, the codegen dispatcher raises the correctness floor structurally: for every dispatched expression,
 results are guaranteed to match Spark exactly because Spark's own generated code does the evaluation. This

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -38,7 +38,7 @@ contributors. See the [change log] for more information.
 
 ## JVM Codegen Dispatch
 
-The headline feature of 0.17.0 is a new mechanism introduced this cycle: Comet's **JVM codegen dispatcher**.
+The headline feature of 0.17.0 is a new mechanism introduced in this release: Comet's **JVM codegen dispatcher**.
 
 Comet has always fallen back to Spark whenever an expression had no native Rust implementation, or where the
 Rust implementation could diverge from Spark on edge cases. A fallback is correct, but it is expensive: the
@@ -103,7 +103,7 @@ Arrow-native rather than hand back to Spark.
 ## Expanded Expression Coverage
 
 Partly through the codegen dispatcher and partly through new Rust implementations, Comet's expression coverage
-grew substantially in this cycle. More than 120 Spark expressions have gained support since 0.16.0, spanning
+grew substantially in this release. More than 120 Spark expressions have gained support since 0.16.0, spanning
 nearly every function family:
 
 - **Date and time** (~25): `convert_timezone`, `make_date`, `months_between`, `next_day`,
@@ -163,12 +163,12 @@ easier to attribute.
 
 ## Correctness and Test Coverage
 
-Much of the correctness work this cycle is part of a deliberate push toward an eventual **1.0.0 release**.
+Much of the correctness work in this release is part of a deliberate push toward an eventual **1.0.0 release**.
 Reaching 1.0.0 means being able to state precisely, and stand behind, exactly which Spark expressions Comet
 accelerates and how faithfully it matches Spark on each one. Two efforts in 0.17.0 move directly toward that
 goal.
 
-First, this cycle included a systematic audit of Comet's expression implementations against Apache Spark
+First, this release included a systematic audit of Comet's expression implementations against Apache Spark
 3.4.3, 3.5.8, 4.0.1, and 4.1.1, covering the hash, JSON, collection, map, predicate, bitwise, conditional,
 array, struct, math, and cast expression families, along with cast behavior. Each audit compared Comet's
 behavior to Spark across all four versions and expanded test coverage where gaps were found.

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -51,6 +51,12 @@ JVM-implemented Arrow-native expression: the query stays in the pipeline, and be
 evaluated by Spark's own code, the result is guaranteed to match Spark exactly across every supported Spark
 version. When the dispatcher is disabled, Comet falls back cleanly as before.
 
+It is worth being clear about where the benefit comes from. A dispatched expression runs Spark's own generated
+code, so the expression itself is not faster than it would be in Spark; expect roughly equivalent per-expression
+performance. The win is structural: a single unsupported expression no longer forces an entire query stage out
+of the Comet pipeline. The surrounding operators stay Arrow-native, and the stage as a whole avoids the
+columnar-to-row conversion and row-based Spark execution that a fallback would otherwise impose.
+
 This release puts the dispatcher to work across a wide surface:
 
 - **Scala and Java UDFs, enabled by default.** Eligible Spark `ScalaUDF` expressions are routed through

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -1,0 +1,205 @@
+---
+layout: post
+title: Apache DataFusion Comet 0.17.0 Release
+date: 2026-06-16
+author: pmc
+categories: [subprojects]
+---
+
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+[TOC]
+
+<!-- TODO before publishing: confirm release date, PR count, and contributor count from the generated 0.17.0 change log. -->
+
+The Apache DataFusion PMC is pleased to announce version 0.17.0 of the [Comet](https://datafusion.apache.org/comet/) subproject.
+
+Comet is an accelerator for Apache Spark that translates Spark physical plans to DataFusion physical plans for
+improved performance and efficiency without requiring any code changes.
+
+This release covers approximately five weeks of development work and is the result of merging XXX PRs from 19
+contributors. See the [change log] for more information.
+
+[change log]: https://github.com/apache/datafusion-comet/blob/main/dev/changelog/0.17.0.md
+
+## Arrow-Native, End to End
+
+Comet's value proposition has always been "keep your Spark data columnar and skip the per-row overhead of
+Spark's row-based engine," but the way we describe it has not always kept pace with how Comet actually works.
+This release leans into a clearer framing: Comet keeps Spark queries **Arrow-native end to end**. Operators,
+expressions, shuffle, and broadcast all stay in Apache Arrow columnar format, avoiding the cost of
+materializing and transitioning row-by-row data.
+
+Within that Arrow-native pipeline, the work of an operator or expression runs in one of two ways:
+
+- **Rust-implemented**: native Rust code, executed through Apache DataFusion. This is what most people picture
+  when they think of Comet.
+- **JVM-implemented**: Scala or Java code that operates directly on Arrow batches, including expressions
+  produced by Spark's own code generation.
+
+The implementation language is an internal detail. From the query's perspective the data never leaves Arrow
+columnar format, so there is no per-row materialization cost at the boundary between a Rust-implemented and a
+JVM-implemented step. This distinction matters for 0.17.0 because the JVM-implemented path, driven by Comet's
+codegen dispatcher, is where a large share of this release's new capability lands.
+
+The framing is now reflected in Comet's documentation: the README leads with the Arrow-native value
+proposition, and the older internal scan names (`native_datafusion`, `native_iceberg_compat`) have been
+retired in favor of clearer terminology.
+
+## JVM Codegen Dispatch
+
+The headline feature of 0.17.0 is the maturation of Comet's **JVM codegen dispatcher**.
+
+Comet has long fallen back to Spark whenever an expression had no native Rust implementation, or where the
+Rust implementation could diverge from Spark on edge cases. A fallback is correct, but it is expensive: the
+surrounding project, exchange, and sort operators drop out of the Comet pipeline, and the data takes a
+columnar-to-row round trip into Spark and back.
+
+The codegen dispatcher offers a third option. Instead of falling back, Comet runs the Spark expression's own
+generated code (`doGenCode`) inside the Comet pipeline, operating directly on Arrow batches. The result is a
+JVM-implemented Arrow-native expression: the query stays in the pipeline, and because the expression is
+evaluated by Spark's own code, the result is guaranteed to match Spark exactly across every supported Spark
+version. When the dispatcher is disabled, Comet falls back cleanly as before.
+
+This release puts the dispatcher to work across a wide surface:
+
+- **Scala and Java UDFs, now enabled by default.** Eligible Spark `ScalaUDF` expressions are routed through
+  the dispatcher and executed inside the Comet pipeline, so a project around a UDF no longer forces a
+  fallback and a columnar-to-row round trip. The path has broad type coverage (scalars, arbitrarily nested
+  complex types, and higher-order functions) and is backed by end-to-end, fuzz, and Iceberg test coverage.
+  It can be disabled with `spark.comet.exec.scalaUDF.codegen.enabled=false`.
+- **100% Spark-compatible regular expressions.** Regex expressions now dispatch to Spark's own
+  implementation, eliminating the long-standing compatibility gaps of a separate native regex engine.
+- **100% Spark-compatible JSON functions.** JSON expression handling follows the same approach, matching
+  Spark's behavior precisely.
+- **More scalar and structured-text functions**, including a batch of math and string functions, AES
+  encryption and decryption, `Upper` / `Lower` / `InitCap`, `GetTimestamp`, and an expanded set of date and
+  time expressions.
+
+Just as importantly, 0.17.0 changes how Comet treats expressions whose native Rust path is known to diverge
+from Spark (marked `Incompatible`). Previously such an expression forced the entire projection back to Spark
+unless the user opted into the divergent native behavior. Now, when `spark.comet.expr.allowIncompatible` is
+left at its default of `false`, the expression is routed through the codegen dispatcher and evaluated
+correctly inside Comet rather than triggering a fallback. `allowIncompatible=true` becomes a pure performance
+knob for users who accept the faster native path's divergence. Expressions such as `from_unixtime`, and the
+`TimestampNTZ` branches of `hour`, `minute`, and `second`, now stay in the pipeline by default.
+
+## Expanded Expression Coverage
+
+Partly through the codegen dispatcher and partly through new Rust implementations, Comet's expression coverage
+grew substantially in this cycle. More than 120 Spark expressions have gained support since 0.16.0, spanning
+nearly every function family:
+
+- **Date and time** (~25): `convert_timezone`, `make_date`, `months_between`, `next_day`,
+  `from_utc_timestamp` / `to_utc_timestamp`, `date_from_unix_date`, the `timestamp_*` and `unix_*` second /
+  milli / micro conversions, and the current date/time/timezone functions.
+- **Math** (~24): `acosh`, `asinh`, `atanh`, `cbrt`, `csc`, `sec`, `hypot`, `log1p`, `bin`, `conv`,
+  `factorial`, `pmod`, `width_bucket`, `rint`, and more.
+- **String** (~16): `elt`, `find_in_set`, `format_number`, `format_string`, `levenshtein`, `locate`,
+  `overlay`, `soundex`, `split`, `substring_index`, `unbase64`, `to_char`, and `to_number`.
+- **XPath** (9): the full `xpath`, `xpath_boolean`, `xpath_double`, `xpath_int`, `xpath_long`, `xpath_string`
+  family.
+- **JSON, CSV, and XML** (9): `from_csv`, `to_csv`, `schema_of_csv`, `schema_of_json`, `json_object_keys`,
+  `json_array_length`, `from_xml`, `to_xml`, and `schema_of_xml`.
+- **Array and map** (11): `array_position`, `array_size`, `arrays_zip`, `slice`, `sort_array`, `sequence`,
+  `map_concat`, `map_contains_key`, and `map_from_entries`.
+- **Aggregate and window** (7): `any_value`, `count_if`, the `regr_*` regression aggregates, plus `lag` and
+  `lead`.
+- **Conditional and null handling** (7): `greatest`, `least`, `nullif`, `ifnull` / `nvl`, `nvl2`, and
+  `equal_null`.
+
+For the authoritative, always-current status of every Spark built-in expression, see the
+[Spark Expression Support](https://datafusion.apache.org/comet/user-guide/latest/expressions.html) reference.
+
+## Performance
+
+### Removing an FFI Round Trip from Native Shuffle
+
+The most significant performance change in 0.17.0 targets the shuffle write path. When a native subtree feeds
+a Comet shuffle, Comet previously ran two separate native iterators per partition: one for the upstream
+subtree, and a second rooted at a synthetic `Scan("ShuffleWriterInput") -> ShuffleWriter` that consumed the
+batches back. The JVM never actually read this data, so the native-to-JVM-and-back hop was pure overhead.
+
+Although the Arrow C Data Interface is zero-copy, this particular round trip was not. The synthetic scan left
+its batches marked as not FFI-safe, so on import every batch was deep-copied into freshly allocated buffers.
+0.17.0 collapses the two iterators into a single native plan rooted at the shuffle writer, with the upstream
+subtree as a direct child. That removes the Arrow FFI export and import, the per-batch deep copy, and one
+`createPlan` / `releasePlan` pair per partition, while preserving all of the existing per-partition setup
+(broadcast alignment, subqueries, encryption) and input metrics reporting. This is the Arrow-native principle
+in practice: the win came not from faster copying, but from removing a data-format boundary that should never
+have cost anything.
+
+### Lower Per-Batch Overhead in Arrow Vectors
+
+Two changes reduce repeated work when reading Arrow columns across the JNI boundary. Comet now caches the
+validity buffer address on `CometDecodedVector` and the offset buffer address for variable-width vectors on
+`CometPlainVector`, so these addresses are resolved once per vector rather than on every access.
+
+### Faster Statistical Aggregates
+
+The variance, standard deviation, covariance, and correlation aggregates now use DataFusion's
+`GroupsAccumulator` interface, which is substantially more efficient for grouped aggregation than the
+row-accumulator path they used previously.
+
+Additional smaller improvements include bulk-NULL handling in `split` and `substring` (skipping a per-row
+allocation), and a new `interleave_time` shuffle metric with tuned output buffer sizing to make shuffle cost
+easier to attribute.
+
+## Correctness and Test Coverage
+
+Much of the correctness work this cycle is part of a deliberate push toward an eventual **1.0.0 release**.
+Reaching 1.0.0 means being able to state precisely, and stand behind, exactly which Spark expressions Comet
+accelerates and how faithfully it matches Spark on each one. Two efforts in 0.17.0 move directly toward that
+goal.
+
+First, this cycle included a systematic audit of Comet's expression implementations against Apache Spark
+3.4.3, 3.5.8, 4.0.1, and 4.1.1, covering the hash, JSON, collection, map, predicate, bitwise, conditional,
+array, struct, math, and cast expression families, along with cast behavior. Each audit compared Comet's
+behavior to Spark across all four versions and expanded test coverage where gaps were found.
+
+Second, the codegen dispatcher raises the correctness floor structurally: for every dispatched expression,
+results are guaranteed to match Spark exactly because Spark's own generated code does the evaluation. Together
+with the audits, this gives a meaningful increase in confidence that Comet matches Spark across the supported
+version matrix, and it sharpens the Spark Expression Support reference into a status page the project can
+commit to as it approaches 1.0.0.
+
+As always, most cross-version behavior differences were caught because Comet runs the full Apache Spark SQL
+test suite against each supported Spark version as part of CI.
+
+## Compatibility
+
+Supported platforms include:
+
+- **Spark 3.4.3** with Java 11/17 and Scala 2.12/2.13
+- **Spark 3.5.8** with Java 11/17 and Scala 2.12/2.13
+- **Spark 4.0.2** with Java 17 and Scala 2.13
+- **Spark 4.1.1** with Java 17 and Scala 2.13
+
+See the [Spark Version Compatibility] page for known limitations specific to each version.
+
+[Spark Version Compatibility]: https://datafusion.apache.org/comet/user-guide/latest/compatibility/spark-versions.html
+
+This release builds on **DataFusion 53.1** and **Arrow 58.3**.
+
+## Get Started with Comet 0.17.0
+
+Ready to try it out? Follow the [Comet 0.17.0 Installation Guide](https://datafusion.apache.org/comet/user-guide/0.17/installation.html)
+to get up and running, then point Comet at your existing Spark workloads, including Scala and Java UDFs and
+Spark 4 with ANSI mode enabled, and see the speedup for yourself.

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -27,11 +27,9 @@ limitations under the License.
 
 [TOC]
 
-<!-- TODO before publishing: confirm release date, PR count, and contributor count from the generated 0.17.0 change log. -->
-
 The Apache DataFusion PMC is pleased to announce version 0.17.0 of the [Comet](https://datafusion.apache.org/comet/) subproject.
 
-This release covers approximately five weeks of development work and is the result of merging XXX PRs from 19
+This release covers approximately five weeks of development work and is the result of merging 192 PRs from 19
 contributors. See the [change log] for more information.
 
 [change log]: https://github.com/apache/datafusion-comet/blob/main/dev/changelog/0.17.0.md
@@ -52,11 +50,11 @@ JVM-implemented Arrow-native expression: the query stays in the pipeline, and be
 evaluated by Spark's own code, the result is guaranteed to match Spark exactly across every supported Spark
 version. When the dispatcher is disabled, Comet falls back cleanly as before.
 
-It is worth being clear about where the benefit comes from. A dispatched expression runs Spark's own generated
-code, so the expression itself is not faster than it would be in Spark; expect roughly equivalent per-expression
-performance. The win is structural: a single unsupported expression no longer forces an entire query stage out
-of the Comet pipeline. The surrounding operators stay Arrow-native, and the stage as a whole avoids the
-columnar-to-row conversion and row-based Spark execution that a fallback would otherwise impose.
+A dispatched expression is no faster than it would be in Spark, since it runs the same generated code. The
+benefit is structural rather than per-expression: a single unsupported expression no longer forces an entire
+query stage out of the Comet pipeline. The surrounding operators stay Arrow-native, and the
+stage avoids the columnar-to-row conversion and row-based Spark execution that a fallback would otherwise
+impose.
 
 This release puts the dispatcher to work across a wide surface:
 
@@ -65,10 +63,17 @@ This release puts the dispatcher to work across a wide surface:
 - **100% Spark-compatible JSON functions.** JSON expression handling follows the same approach, matching
   Spark's behavior precisely.
 - **More scalar and structured-text functions**, including a batch of math and string functions, AES
-  encryption and decryption, `Upper` / `Lower` / `InitCap`, `GetTimestamp`, and an expanded set of date and
-  time expressions.
+  encryption and decryption (`aes_encrypt` / `aes_decrypt` / `try_aes_decrypt`), `Upper` / `Lower` /
+  `InitCap`, `GetTimestamp`, `mask`, `try_to_number`, and an expanded set of date, time, and
+  timezone expressions.
+- **Collection and higher-order expressions**, including `array_intersect`, `array_except`, `array_join`,
+  `create_map`, and lambda-based higher-order functions such as `filter`.
 
-Just as importantly, 0.17.0 changes how Comet treats expressions whose native Rust path is known to diverge
+Several expressions that have native Rust paths are also routed through the dispatcher where it yields exact
+Spark behavior, including `StringReplace`, `decode`, and the `from_utc_timestamp` / `to_utc_timestamp` /
+`convert_timezone` family, which now honor Spark 4.0 legacy flags.
+
+0.17.0 also changes how Comet treats expressions whose native Rust path is known to diverge
 from Spark (marked `Incompatible`). Previously such an expression forced the entire projection back to Spark
 unless the user opted into the divergent native behavior. Now, when `spark.comet.expr.allowIncompatible` is
 left at its default of `false`, the expression is routed through the codegen dispatcher and evaluated
@@ -102,16 +107,15 @@ Within that Arrow-native pipeline, the work of an operator or expression runs in
   codegen-dispatched expressions and UDFs described above.
 
 Because the data never leaves Arrow columnar format, there is no per-row materialization cost at the boundary
-between a Rust-implemented and a JVM-implemented step. That is what makes dispatch worthwhile: a dispatched
-expression sits directly in the pipeline alongside Rust-implemented operators, with no columnar-to-row
-transition between them. The expansion of the JVM-implemented path in 0.17.0 widens what Comet can keep
-Arrow-native rather than hand back to Spark.
+between a Rust-implemented and a JVM-implemented step. A dispatched expression sits in the pipeline alongside
+Rust-implemented operators with no columnar-to-row transition between them. Expanding the JVM-implemented path
+in 0.17.0 lets Comet keep more work Arrow-native instead of handing it back to Spark.
 
 ## Expanded Expression Coverage
 
 Partly through the codegen dispatcher and partly through new Rust implementations, Comet's expression coverage
-grew substantially in this release. More than 120 Spark expressions have gained support since 0.16.0, spanning
-nearly every function family:
+grew substantially in this release. More than 120 Spark expressions have gained support since 0.16.0, across
+most function families:
 
 - **Date and time** (~25): `convert_timezone`, `make_date`, `months_between`, `next_day`,
   `from_utc_timestamp` / `to_utc_timestamp`, `date_from_unix_date`, the `timestamp_*` and `unix_*` second /
@@ -134,6 +138,9 @@ nearly every function family:
 For the authoritative, always-current status of every Spark built-in expression, see the
 [Spark Expression Support](https://datafusion.apache.org/comet/user-guide/latest/expressions.html) reference.
 
+Operator coverage grew too: 0.17.0 adds a native **broadcast nested loop join**, so queries with non-equi or
+cross join conditions can now stay in the Comet pipeline rather than falling back to Spark.
+
 ## Performance
 
 ### Removing an FFI Round Trip from Native Shuffle
@@ -148,9 +155,20 @@ its batches marked as not FFI-safe, so on import every batch was deep-copied int
 0.17.0 collapses the two iterators into a single native plan rooted at the shuffle writer, with the upstream
 subtree as a direct child. That removes the Arrow FFI export and import, the per-batch deep copy, and one
 `createPlan` / `releasePlan` pair per partition, while preserving all of the existing per-partition setup
-(broadcast alignment, subqueries, encryption) and input metrics reporting. This is the Arrow-native principle
-in practice: the win came not from faster copying, but from removing a data-format boundary that should never
-have cost anything.
+(broadcast alignment, subqueries, encryption) and input metrics reporting. The gain comes from removing the
+round trip, not from copying its data more efficiently.
+
+### A Single Arrow Stream on the Input Path
+
+0.17.0 also reworks the other side of the JVM/native boundary — the path that feeds JVM-sourced data *into*
+native execution. Previously each batch crossed via a bespoke `CometBatchIterator`, with a `hasNext` / `next`
+JNI pair per batch and every column imported through its own Arrow FFI array and schema. This release replaces
+that path with the **Arrow C Stream Interface**: the JVM exports each per-partition iterator once, and native
+imports the schema once and pulls each batch through a single C callback, taking ownership by reference count.
+This removes the per-batch, per-column FFI export and JNI round trips for all JVM-sourced inputs, lets the
+old `CometBatchIterator` and a now-unnecessary deep copy be deleted, and is the input-side counterpart to the
+shuffle-write change above. On TPC-H SF1000 (Spark 3.5.8), total runtime dropped from 475.3s on the previous
+baseline to 450.9s with the shuffle-write change and 435.1s with this one.
 
 ### Lower Per-Batch Overhead in Arrow Vectors
 
@@ -170,7 +188,7 @@ easier to attribute.
 
 ## Preparing for the 1.0.0 Release
 
-Much of the correctness work in this release is part of a deliberate push toward an eventual **1.0.0 release**.
+Much of the correctness work in this release is part of an ongoing push toward a **1.0.0 release**.
 Planning for 1.0.0 is being tracked in [issue #4082], where the community is discussing what the milestone
 should mean. The criteria under consideration go well beyond correctness and include:
 
@@ -184,15 +202,14 @@ should mean. The criteria under consideration go well beyond correctness and inc
 
 [issue #4082]: https://github.com/apache/datafusion-comet/issues/4082
 
-Correctness sits at the center of that list: reaching 1.0.0 means being able to state precisely, and stand
-behind, exactly which Spark expressions Comet accelerates and how faithfully it matches Spark on each one. Two
-efforts in 0.17.0 move directly toward that goal.
+Correctness is central to that list: reaching 1.0.0 means being able to state precisely which Spark
+expressions Comet accelerates, and how faithfully it matches Spark on each one. Two efforts in 0.17.0 move
+toward that goal.
 
-First, the codegen dispatcher raises the correctness floor structurally: for every dispatched expression,
-results are guaranteed to match Spark exactly because Spark's own generated code does the evaluation. This
-gives a meaningful increase in confidence that Comet matches Spark across the supported version matrix, and it
-sharpens the Spark Expression Support reference into a status page the project can commit to as it approaches
-1.0.0.
+First, the codegen dispatcher guarantees an exact match for every dispatched expression, since Spark's own
+generated code does the evaluation. That raises our confidence that Comet matches Spark across the supported
+versions, and it makes the Spark Expression Support reference something the project can stand behind as it
+approaches 1.0.0.
 
 Second, this release included a systematic audit of Comet's existing expression implementations against Spark,
 detailed below.
@@ -204,7 +221,7 @@ covering the hash, JSON, collection, map, predicate, bitwise, conditional, array
 expression families, along with cast behavior. Each audit compared Comet's behavior to Spark across all four
 versions and expanded test coverage where gaps were found.
 
-This deliberate, edge-case-by-edge-case study surfaced the bulk of the behavior differences fixed in this
+This edge-case-by-edge-case comparison surfaced most of the behavior differences fixed in this
 release. By working through each expression's corner cases and writing targeted Comet SQL tests for them, the
 audit caught divergences that broader testing does not reliably exercise. Comet also runs the full Apache
 Spark SQL test suite against each supported Spark version as part of CI, which continues to catch some
@@ -217,7 +234,7 @@ Supported platforms include:
 - **Spark 3.4.3** with Java 11/17 and Scala 2.12/2.13
 - **Spark 3.5.8** with Java 11/17 and Scala 2.12/2.13
 - **Spark 4.0.2** with Java 17 and Scala 2.13
-- **Spark 4.1.1** with Java 17 and Scala 2.13
+- **Spark 4.1.2** with Java 17 and Scala 2.13
 
 See the [Spark Version Compatibility] page for known limitations specific to each version.
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -191,8 +191,11 @@ covering the hash, JSON, collection, map, predicate, bitwise, conditional, array
 expression families, along with cast behavior. Each audit compared Comet's behavior to Spark across all four
 versions and expanded test coverage where gaps were found.
 
-As always, most cross-version behavior differences were caught because Comet runs the full Apache Spark SQL
-test suite against each supported Spark version as part of CI.
+This deliberate, edge-case-by-edge-case study surfaced the bulk of the behavior differences fixed in this
+release. By working through each expression's corner cases and writing targeted Comet SQL tests for them, the
+audit caught divergences that broader testing does not reliably exercise. Comet also runs the full Apache
+Spark SQL test suite against each supported Spark version as part of CI, which continues to catch some
+cross-version differences, but the audit's focused approach found considerably more.
 
 ## Compatibility
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -36,24 +36,6 @@ contributors. See the [change log] for more information.
 
 [change log]: https://github.com/apache/datafusion-comet/blob/main/dev/changelog/0.17.0.md
 
-## Arrow-Native, End to End
-
-Comet keeps Spark queries **Arrow-native end to end**: operators, expressions, shuffle, and broadcast all stay
-in Apache Arrow columnar format, avoiding the per-row overhead that Spark's row-based engine incurs from
-materializing and transitioning data one row at a time.
-
-Within that Arrow-native pipeline, the work of an operator or expression runs in one of two ways:
-
-- **Rust-implemented**: native Rust code, executed through Apache DataFusion. This is what most people picture
-  when they think of Comet.
-- **JVM-implemented**: Scala or Java code that operates directly on Arrow batches, including expressions
-  produced by Spark's own code generation.
-
-Because the data never leaves Arrow columnar format, there is no per-row materialization cost at the boundary
-between a Rust-implemented and a JVM-implemented step. 0.17.0 extends both paths, but it builds especially
-heavily on the JVM-implemented one: its codegen dispatcher brings a large set of new expressions, UDF support,
-and exact Spark compatibility into the Arrow-native pipeline, as the following sections describe.
-
 ## JVM Codegen Dispatch
 
 The headline feature of 0.17.0 is the maturation of Comet's **JVM codegen dispatcher**.
@@ -91,6 +73,26 @@ left at its default of `false`, the expression is routed through the codegen dis
 correctly inside Comet rather than triggering a fallback. `allowIncompatible=true` becomes a pure performance
 knob for users who accept the faster native path's divergence. Expressions such as `from_unixtime`, and the
 `TimestampNTZ` branches of `hour`, `minute`, and `second`, now stay in the pipeline by default.
+
+## Arrow-Native, End to End
+
+The codegen dispatcher works because of a property that runs through all of Comet: queries stay **Arrow-native
+end to end**. Operators, expressions, shuffle, and broadcast all remain in Apache Arrow columnar format,
+avoiding the per-row overhead that Spark's row-based engine incurs from materializing and transitioning data
+one row at a time.
+
+Within that Arrow-native pipeline, the work of an operator or expression runs in one of two ways:
+
+- **Rust-implemented**: native Rust code, executed through Apache DataFusion. This is what most people picture
+  when they think of Comet.
+- **JVM-implemented**: Scala or Java code that operates directly on Arrow batches, including the
+  codegen-dispatched expressions and UDFs described above.
+
+Because the data never leaves Arrow columnar format, there is no per-row materialization cost at the boundary
+between a Rust-implemented and a JVM-implemented step. That is what makes dispatch worthwhile: a dispatched
+expression sits directly in the pipeline alongside Rust-implemented operators, with no columnar-to-row
+transition between them. The expansion of the JVM-implemented path in 0.17.0 widens what Comet can keep
+Arrow-native rather than hand back to Spark.
 
 ## Expanded Expression Coverage
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -36,9 +36,10 @@ contributors. See the [change log] for more information.
 
 [change log]: https://github.com/apache/datafusion-comet/blob/main/dev/changelog/0.17.0.md
 
-## JVM Codegen Dispatch
+## Fewer Fallbacks to Spark
 
-The headline feature of 0.17.0 is a new mechanism introduced in this release: Comet's **JVM codegen dispatcher**.
+The headline feature of 0.17.0 is a new mechanism that keeps more of your query running inside Comet instead
+of falling back to Spark: the **JVM codegen dispatcher**.
 
 Comet has always fallen back to Spark whenever an expression had no native Rust implementation, or where the
 Rust implementation could diverge from Spark on edge cases. A fallback is correct, but it is expensive: the
@@ -161,23 +162,28 @@ Additional smaller improvements include bulk-NULL handling in `split` and `subst
 allocation), and a new `interleave_time` shuffle metric with tuned output buffer sizing to make shuffle cost
 easier to attribute.
 
-## Correctness and Test Coverage
+## Preparing for the 1.0.0 Release
 
 Much of the correctness work in this release is part of a deliberate push toward an eventual **1.0.0 release**.
 Reaching 1.0.0 means being able to state precisely, and stand behind, exactly which Spark expressions Comet
 accelerates and how faithfully it matches Spark on each one. Two efforts in 0.17.0 move directly toward that
 goal.
 
-First, this release included a systematic audit of Comet's expression implementations against Apache Spark
-3.4.3, 3.5.8, 4.0.1, and 4.1.1, covering the hash, JSON, collection, map, predicate, bitwise, conditional,
-array, struct, math, and cast expression families, along with cast behavior. Each audit compared Comet's
-behavior to Spark across all four versions and expanded test coverage where gaps were found.
+First, the codegen dispatcher raises the correctness floor structurally: for every dispatched expression,
+results are guaranteed to match Spark exactly because Spark's own generated code does the evaluation. This
+gives a meaningful increase in confidence that Comet matches Spark across the supported version matrix, and it
+sharpens the Spark Expression Support reference into a status page the project can commit to as it approaches
+1.0.0.
 
-Second, the codegen dispatcher raises the correctness floor structurally: for every dispatched expression,
-results are guaranteed to match Spark exactly because Spark's own generated code does the evaluation. Together
-with the audits, this gives a meaningful increase in confidence that Comet matches Spark across the supported
-version matrix, and it sharpens the Spark Expression Support reference into a status page the project can
-commit to as it approaches 1.0.0.
+Second, this release included a systematic audit of Comet's existing expression implementations against Spark,
+detailed below.
+
+### Expression Audit
+
+The audit compared Comet's expression implementations against Apache Spark 3.4.3, 3.5.8, 4.0.1, and 4.1.1,
+covering the hash, JSON, collection, map, predicate, bitwise, conditional, array, struct, math, and cast
+expression families, along with cast behavior. Each audit compared Comet's behavior to Spark across all four
+versions and expanded test coverage where gaps were found.
 
 As always, most cross-version behavior differences were caught because Comet runs the full Apache Spark SQL
 test suite against each supported Spark version as part of CI.

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -38,12 +38,12 @@ contributors. See the [change log] for more information.
 
 ## JVM Codegen Dispatch
 
-The headline feature of 0.17.0 is the maturation of Comet's **JVM codegen dispatcher**.
+The headline feature of 0.17.0 is a new mechanism introduced this cycle: Comet's **JVM codegen dispatcher**.
 
-Comet has long fallen back to Spark whenever an expression had no native Rust implementation, or where the
+Comet has always fallen back to Spark whenever an expression had no native Rust implementation, or where the
 Rust implementation could diverge from Spark on edge cases. A fallback is correct, but it is expensive: the
-surrounding project, exchange, and sort operators drop out of the Comet pipeline, and the data takes a
-columnar-to-row round trip into Spark and back.
+surrounding project, exchange, and sort operators drop out of the Comet pipeline, and a columnar-to-row
+conversion is needed to feed the data into Spark's row-based operators.
 
 The codegen dispatcher offers a third option. Instead of falling back, Comet runs the Spark expression's own
 generated code (`doGenCode`) inside the Comet pipeline, operating directly on Arrow batches. The result is a
@@ -53,9 +53,9 @@ version. When the dispatcher is disabled, Comet falls back cleanly as before.
 
 This release puts the dispatcher to work across a wide surface:
 
-- **Scala and Java UDFs, now enabled by default.** Eligible Spark `ScalaUDF` expressions are routed through
+- **Scala and Java UDFs, enabled by default.** Eligible Spark `ScalaUDF` expressions are routed through
   the dispatcher and executed inside the Comet pipeline, so a project around a UDF no longer forces a
-  fallback and a columnar-to-row round trip. The path has broad type coverage (scalars, arbitrarily nested
+  fallback and a columnar-to-row conversion. The path has broad type coverage (scalars, arbitrarily nested
   complex types, and higher-order functions) and is backed by end-to-end, fuzz, and Iceberg test coverage.
   It can be disabled with `spark.comet.exec.scalaUDF.codegen.enabled=false`.
 - **100% Spark-compatible regular expressions.** Regex expressions now dispatch to Spark's own

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -168,7 +168,8 @@ that path with the **Arrow C Stream Interface**: the JVM exports each per-partit
 imports the schema once and pulls each batch through a single C callback, taking ownership by reference count.
 This removes the per-batch, per-column FFI export and JNI round trips for all JVM-sourced inputs, lets the
 old `CometBatchIterator` and a now-unnecessary deep copy be deleted, and is the input-side counterpart to the
-shuffle-write change above. Together, the two FFI changes improve TPC-DS performance at 1TB by around 9%.
+shuffle-write change above. TPC-DS at 1TB is about 9% faster in 0.17.0 than in 0.16.0, and these two FFI
+changes are the largest contributor to that gain.
 
 ### Lower Per-Batch Overhead in Arrow Vectors
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -31,11 +31,6 @@ limitations under the License.
 
 The Apache DataFusion PMC is pleased to announce version 0.17.0 of the [Comet](https://datafusion.apache.org/comet/) subproject.
 
-Comet is an accelerator for Apache Spark that keeps query execution in Apache Arrow columnar format end to
-end, running operators and expressions as native Rust code (via Apache DataFusion) or as JVM code that
-operates directly on Arrow batches, for improved performance and efficiency without requiring any code
-changes.
-
 This release covers approximately five weeks of development work and is the result of merging XXX PRs from 19
 contributors. See the [change log] for more information.
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -75,11 +75,12 @@ Spark behavior, including `StringReplace`, `decode`, and the `from_utc_timestamp
 
 0.17.0 also changes how Comet treats expressions whose native Rust path is known to diverge
 from Spark (marked `Incompatible`). Previously such an expression forced the entire projection back to Spark
-unless the user opted into the divergent native behavior. Now, when `spark.comet.expr.allowIncompatible` is
-left at its default of `false`, the expression is routed through the codegen dispatcher and evaluated
-correctly inside Comet rather than triggering a fallback. `allowIncompatible=true` becomes a pure performance
-knob for users who accept the faster native path's divergence. Expressions such as `from_unixtime`, and the
-`TimestampNTZ` branches of `hour`, `minute`, and `second`, now stay in the pipeline by default.
+unless the user opted into the divergent native behavior with the per-expression
+`spark.comet.expression.<name>.allowIncompatible` flag. By default that flag is unset, and the expression is
+now routed through the codegen dispatcher and evaluated correctly inside Comet rather than triggering a
+fallback. Setting it to `true` becomes a performance knob for users who accept the faster native path's
+divergence. Expressions such as `from_unixtime`, and the `TimestampNTZ` branches of `hour`, `minute`, and
+`second`, now stay in the pipeline by default.
 
 ## User-Defined Functions in Java and Scala
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -31,8 +31,10 @@ limitations under the License.
 
 The Apache DataFusion PMC is pleased to announce version 0.17.0 of the [Comet](https://datafusion.apache.org/comet/) subproject.
 
-Comet is an accelerator for Apache Spark that translates Spark physical plans to DataFusion physical plans for
-improved performance and efficiency without requiring any code changes.
+Comet is an accelerator for Apache Spark that keeps query execution in Apache Arrow columnar format end to
+end, running operators and expressions as native Rust code (via Apache DataFusion) or as JVM code that
+operates directly on Arrow batches, for improved performance and efficiency without requiring any code
+changes.
 
 This release covers approximately five weeks of development work and is the result of merging XXX PRs from 19
 contributors. See the [change log] for more information.

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -168,8 +168,7 @@ that path with the **Arrow C Stream Interface**: the JVM exports each per-partit
 imports the schema once and pulls each batch through a single C callback, taking ownership by reference count.
 This removes the per-batch, per-column FFI export and JNI round trips for all JVM-sourced inputs, lets the
 old `CometBatchIterator` and a now-unnecessary deep copy be deleted, and is the input-side counterpart to the
-shuffle-write change above. On TPC-H SF1000 (Spark 3.5.8), total runtime dropped from 475.3s on the previous
-baseline to 450.9s with the shuffle-write change and 435.1s with this one.
+shuffle-write change above. Together, the two FFI changes improve TPC-DS performance at 1TB by around 9%.
 
 ### Lower Per-Batch Overhead in Arrow Vectors
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -41,11 +41,9 @@ contributors. See the [change log] for more information.
 
 ## Arrow-Native, End to End
 
-Comet's value proposition has always been "keep your Spark data columnar and skip the per-row overhead of
-Spark's row-based engine," but the way we describe it has not always kept pace with how Comet actually works.
-This release leans into a clearer framing: Comet keeps Spark queries **Arrow-native end to end**. Operators,
-expressions, shuffle, and broadcast all stay in Apache Arrow columnar format, avoiding the cost of
-materializing and transitioning row-by-row data.
+Comet keeps Spark queries **Arrow-native end to end**: operators, expressions, shuffle, and broadcast all stay
+in Apache Arrow columnar format, avoiding the per-row overhead that Spark's row-based engine incurs from
+materializing and transitioning data one row at a time.
 
 Within that Arrow-native pipeline, the work of an operator or expression runs in one of two ways:
 
@@ -54,14 +52,10 @@ Within that Arrow-native pipeline, the work of an operator or expression runs in
 - **JVM-implemented**: Scala or Java code that operates directly on Arrow batches, including expressions
   produced by Spark's own code generation.
 
-The implementation language is an internal detail. From the query's perspective the data never leaves Arrow
-columnar format, so there is no per-row materialization cost at the boundary between a Rust-implemented and a
-JVM-implemented step. This distinction matters for 0.17.0 because the JVM-implemented path, driven by Comet's
-codegen dispatcher, is where a large share of this release's new capability lands.
-
-The framing is now reflected in Comet's documentation: the README leads with the Arrow-native value
-proposition, and the older internal scan names (`native_datafusion`, `native_iceberg_compat`) have been
-retired in favor of clearer terminology.
+Because the data never leaves Arrow columnar format, there is no per-row materialization cost at the boundary
+between a Rust-implemented and a JVM-implemented step. 0.17.0 extends both paths, but it builds especially
+heavily on the JVM-implemented one: its codegen dispatcher brings a large set of new expressions, UDF support,
+and exact Spark compatibility into the Arrow-native pipeline, as the following sections describe.
 
 ## JVM Codegen Dispatch
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -60,11 +60,6 @@ columnar-to-row conversion and row-based Spark execution that a fallback would o
 
 This release puts the dispatcher to work across a wide surface:
 
-- **Scala and Java UDFs, enabled by default.** Eligible Spark `ScalaUDF` expressions are routed through
-  the dispatcher and executed inside the Comet pipeline, so a project around a UDF no longer forces a
-  fallback and a columnar-to-row conversion. The path has broad type coverage (scalars, arbitrarily nested
-  complex types, and higher-order functions) and is backed by end-to-end, fuzz, and Iceberg test coverage.
-  It can be disabled with `spark.comet.exec.scalaUDF.codegen.enabled=false`.
 - **100% Spark-compatible regular expressions.** Regex expressions now dispatch to Spark's own
   implementation, eliminating the long-standing compatibility gaps of a separate native regex engine.
 - **100% Spark-compatible JSON functions.** JSON expression handling follows the same approach, matching
@@ -80,6 +75,17 @@ left at its default of `false`, the expression is routed through the codegen dis
 correctly inside Comet rather than triggering a fallback. `allowIncompatible=true` becomes a pure performance
 knob for users who accept the faster native path's divergence. Expressions such as `from_unixtime`, and the
 `TimestampNTZ` branches of `hour`, `minute`, and `second`, now stay in the pipeline by default.
+
+## User-Defined Functions in Java and Scala
+
+Building on the codegen dispatcher, 0.17.0 adds support for arbitrary user-defined functions written in Java
+and Scala, enabled by default. Eligible Spark `ScalaUDF` expressions are routed through the dispatcher and
+executed inside the Comet pipeline, so a project around a UDF no longer forces a fallback and a
+columnar-to-row conversion.
+
+The path has broad type coverage — scalars, arbitrarily nested complex types, and higher-order functions — and
+is backed by end-to-end, fuzz, and Iceberg test coverage. It can be disabled with
+`spark.comet.exec.scalaUDF.codegen.enabled=false`.
 
 ## Arrow-Native, End to End
 

--- a/content/blog/2026-06-16-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-16-datafusion-comet-0.17.0.md
@@ -73,6 +73,10 @@ Several expressions that have native Rust paths are also routed through the disp
 Spark behavior, including `StringReplace`, `decode`, and the `from_utc_timestamp` / `to_utc_timestamp` /
 `convert_timezone` family, which now honor Spark 4.0 legacy flags.
 
+The codegen dispatcher closes the compatibility gap, but a dispatched expression runs Spark's own generated
+code and is therefore no faster than Spark itself. Providing native Rust implementations of many of these
+expressions remains ongoing work, and is where the additional acceleration will come from in future releases.
+
 0.17.0 also changes how Comet treats expressions whose native Rust path is known to diverge
 from Spark (marked `Incompatible`). Previously such an expression forced the entire projection back to Spark
 unless the user opted into the divergent native behavior with the per-expression

--- a/content/blog/2026-06-20-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-20-datafusion-comet-0.17.0.md
@@ -40,8 +40,8 @@ The headline feature of 0.17.0 is a new mechanism that keeps more of your query 
 of falling back to Spark: the **JVM codegen dispatcher**.
 
 Comet has always fallen back to Spark row-based execution whenever an expression had no native Rust implementation, or where the
-Rust implementation could diverge from Spark on edge cases. A fallback is correct, a columnar-to-row
-conversion is needed to feed the data into Spark's row-based operators and this adds overhead when processing billions of rows of data.
+Rust implementation could diverge from Spark on edge cases. A fallback is correct, but a columnar-to-row
+conversion is needed to feed the data into Spark's row-based operators, which adds overhead when processing billions of rows of data.
 
 The codegen dispatcher avoids the fallback to row-based processing by running Spark's own
 generated code (`doGenCode`) inside the Comet pipeline, operating directly on Arrow batches. The result is a

--- a/content/blog/2026-06-20-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-20-datafusion-comet-0.17.0.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Apache DataFusion Comet 0.17.0 Release
-date: 2026-06-16
+date: 2026-06-20
 author: pmc
 categories: [subprojects]
 ---
@@ -39,20 +39,19 @@ contributors. See the [change log] for more information.
 The headline feature of 0.17.0 is a new mechanism that keeps more of your query running inside Comet instead
 of falling back to Spark: the **JVM codegen dispatcher**.
 
-Comet has always fallen back to Spark whenever an expression had no native Rust implementation, or where the
-Rust implementation could diverge from Spark on edge cases. A fallback is correct, but it is expensive: the
-surrounding project, exchange, and sort operators drop out of the Comet pipeline, and a columnar-to-row
-conversion is needed to feed the data into Spark's row-based operators.
+Comet has always fallen back to Spark row-based execution whenever an expression had no native Rust implementation, or where the
+Rust implementation could diverge from Spark on edge cases. A fallback is correct, a columnar-to-row
+conversion is needed to feed the data into Spark's row-based operators and this adds overhead when processing billions of rows of data.
 
-The codegen dispatcher offers a third option. Instead of falling back, Comet runs the Spark expression's own
+The codegen dispatcher avoids the fallback to row-based processing by running Spark's own
 generated code (`doGenCode`) inside the Comet pipeline, operating directly on Arrow batches. The result is a
-JVM-implemented Arrow-native expression: the query stays in the pipeline, and because the expression is
+JVM-implemented Arrow-native expression: the data stays in Arrow format, and because the expression is
 evaluated by Spark's own code, the result is guaranteed to match Spark exactly across every supported Spark
 version. When the dispatcher is disabled, Comet falls back cleanly as before.
 
 A dispatched expression is no faster than it would be in Spark, since it runs the same generated code. The
-benefit is structural rather than per-expression: a single unsupported expression no longer forces an entire
-query stage out of the Comet pipeline. The surrounding operators stay Arrow-native, and the
+benefit is that a single unsupported expression no longer forces an entire
+query stage back to row-based execution. The surrounding operators stay Arrow-native, and the
 stage avoids the columnar-to-row conversion and row-based Spark execution that a fallback would otherwise
 impose.
 
@@ -69,22 +68,14 @@ This release puts the dispatcher to work across a wide surface:
 - **Collection and higher-order expressions**, including `array_intersect`, `array_except`, `array_join`,
   `create_map`, and lambda-based higher-order functions such as `filter`.
 
-Several expressions that have native Rust paths are also routed through the dispatcher where it yields exact
-Spark behavior, including `StringReplace`, `decode`, and the `from_utc_timestamp` / `to_utc_timestamp` /
-`convert_timezone` family, which now honor Spark 4.0 legacy flags.
-
-The codegen dispatcher closes the compatibility gap, but a dispatched expression runs Spark's own generated
-code and is therefore no faster than Spark itself. Providing native Rust implementations of many of these
-expressions remains ongoing work, and is where the additional acceleration will come from in future releases.
-
-0.17.0 also changes how Comet treats expressions whose native Rust path is known to diverge
-from Spark (marked `Incompatible`). Previously such an expression forced the entire projection back to Spark
-unless the user opted into the divergent native behavior with the per-expression
-`spark.comet.expression.<name>.allowIncompatible` flag. By default that flag is unset, and the expression is
-now routed through the codegen dispatcher and evaluated correctly inside Comet rather than triggering a
-fallback. Setting it to `true` becomes a performance knob for users who accept the faster native path's
-divergence. Expressions such as `from_unixtime`, and the `TimestampNTZ` branches of `hour`, `minute`, and
-`second`, now stay in the pipeline by default.
+  0.17.0 also changes how Comet treats expressions whose native Rust path is known to diverge
+  from Spark (marked `Incompatible`). Previously such an expression forced the entire projection back to Spark
+  unless the user opted into the divergent native behavior with the per-expression
+  `spark.comet.expression.<name>.allowIncompatible` flag. By default, that flag is unset, and the expression is
+  now routed through the codegen dispatcher and evaluated correctly inside Comet rather than triggering a
+  fallback. Setting it to `true` becomes a performance knob for users who accept the faster native path's
+  divergence. Expressions such as `from_unixtime`, and the `TimestampNTZ` branches of `hour`, `minute`, and
+  `second`, now stay in the pipeline by default.
 
 ## User-Defined Functions in Java and Scala
 
@@ -140,8 +131,8 @@ most function families:
 - **Conditional and null handling** (7): `greatest`, `least`, `nullif`, `ifnull` / `nvl`, `nvl2`, and
   `equal_null`.
 
-For the authoritative, always-current status of every Spark built-in expression, see the
-[Spark Expression Support](https://datafusion.apache.org/comet/user-guide/latest/expressions.html) reference.
+For the full list of supported expressions in this release, see the
+[Spark Expression Support](https://datafusion.apache.org/comet/user-guide/0.17/expressions.html) reference.
 
 Operator coverage grew too: 0.17.0 adds a native **broadcast nested loop join**, so queries with non-equi or
 cross join conditions can now stay in the Comet pipeline rather than falling back to Spark.
@@ -165,7 +156,7 @@ round trip, not from copying its data more efficiently.
 
 ### A Single Arrow Stream on the Input Path
 
-0.17.0 also reworks the other side of the JVM/native boundary — the path that feeds JVM-sourced data *into*
+0.17.0 also reworks the other side of the JVM/native boundary — the path that feeds JVM-sourced data _into_
 native execution. Previously each batch crossed via a bespoke `CometBatchIterator`, with a `hasNext` / `next`
 JNI pair per batch and every column imported through its own Arrow FFI array and schema. This release replaces
 that path with the **Arrow C Stream Interface**: the JVM exports each per-partition iterator once, and native
@@ -197,13 +188,13 @@ Much of the correctness work in this release is part of an ongoing push toward a
 Planning for 1.0.0 is being tracked in [issue #4082], where the community is discussing what the milestone
 should mean. The criteria under consideration go well beyond correctness and include:
 
-- Demonstrated cost savings for TPC-H and TPC-DS at SF1000 (1TB) — already met
+- Demonstrated cost savings for TPC-H and TPC-DS at SF1000 (1TB)
 - Thorough documentation of compatibility status
 - A review of all configuration options, renaming some for consistency
 - Consistent logging
 - A documented policy for how long each Spark version will be supported
 - A documented process for preventing major performance regressions
-- A documented semantic-versioning policy and what it means for Comet going forward — already agreed
+- A documented semantic-versioning policy and what it means for Comet going forward
 
 [issue #4082]: https://github.com/apache/datafusion-comet/issues/4082
 

--- a/content/blog/2026-06-20-datafusion-comet-0.17.0.md
+++ b/content/blog/2026-06-20-datafusion-comet-0.17.0.md
@@ -47,7 +47,7 @@ The codegen dispatcher avoids the fallback to row-based processing by running Sp
 generated code (`doGenCode`) inside the Comet pipeline, operating directly on Arrow batches. The result is a
 JVM-implemented Arrow-native expression: the data stays in Arrow format, and because the expression is
 evaluated by Spark's own code, the result is guaranteed to match Spark exactly across every supported Spark
-version. When the dispatcher is disabled, Comet falls back cleanly as before.
+version. When the dispatcher is disabled, Comet falls back as before.
 
 A dispatched expression is no faster than it would be in Spark, since it runs the same generated code. The
 benefit is that a single unsupported expression no longer forces an entire


### PR DESCRIPTION
Draft release announcement for Apache DataFusion Comet 0.17.0.

The post is structured as a standard PMC release announcement, with the focus on this cycle's headline work:

- **Arrow-native framing**: leads with the "Arrow-native end to end" value proposition and the Rust-implemented vs JVM-implemented distinction, following the nomenclature direction in apache/datafusion-comet#4419.
- **JVM codegen dispatch**: the maturation of the codegen dispatcher (Scala/Java UDFs enabled by default, 100% Spark-compatible regex and JSON, additional scalar/text functions, and the `Incompatible`-to-dispatch change).
- **Expanded expression coverage**: more than 120 Spark expressions newly supported since 0.16.0, curated by category.
- **Performance**: removing the Arrow FFI round trip and per-batch deep copy from the native shuffle write path, Arrow vector buffer-address caching, and `GroupsAccumulator` for statistical aggregates.
- **Correctness**: the cross-version expression audits, framed as preparation toward a future 1.0.0 release.

Opening as a **draft** because the following still need to be finalized at release time (flagged with a TODO comment in the post):

- Release date (filename and front matter currently use a placeholder)
- PR count and contributor count (to be confirmed against the generated `dev/changelog/0.17.0.md`)
- The expressions reference, installation, and changelog links assume the standard release-doc publishing

Feedback welcome on scope: a few other 0.17.0 themes (Iceberg `RewriteDataFiles` native scan, `NullType` shuffle support, pluggable S3 credentials) were intentionally left out to keep the focus tight.
